### PR TITLE
make command timeout longer

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,7 +33,7 @@
     
     var RE_PLUGIN_FOLDER_NAME_MATCHER = /\.generate$/;
 
-    var REQUEST_TIMEOUT = 5000; // milliseconds. TODO: Make configurable
+    var REQUEST_TIMEOUT = 20000; // milliseconds. TODO: Make configurable
     
     function rejectAfter(deferred, timeout) {
         var rejectTimer = setTimeout(function () {

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -40,7 +40,7 @@
     var DEFAULT_PASSWORD       = "password",
         DEFAULT_PORT           = 49494,
         DEFAULT_HOSTNAME       = "localhost",
-        AUTHENTICATION_TIMEOUT = 5000, //milliseconds
+        AUTHENTICATION_TIMEOUT = 20000, //milliseconds
         KEEPALIVE_DELAY        = 1000; //milliseconds
         
     var CONNECTION_STATES = {


### PR DESCRIPTION
Because user's computers are doing a bunch of stuff during PS startup, the authentication sometimes takes longer than 5 seconds.

This pull gives everything a 20 second timeout.

Long term, we should probably move the "auth" step (which isn't really auth) into generator.js rather than photoshop.js and change the way timeouts are managed. photoshop.js probably shouldn't have any notion of timeouts, it should just wrap KVLR. Will file a bug.
