### PR TITLE
Remove plugins folder and clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 node_modules
-/bin/
 /logs/
 /temp/

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Long ago, the "plugins" folder was magic, but it isn't anymore. Moreover, it really doesn't make sense to install plugins inside the Generator core (esp. after we start using it as a grunt-like module).

So, it's time for it to go...
