### PR TITLE
add a simple config file parser

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,8 +29,10 @@
         application: "Adobe Photoshop CC",
         module:      "Generator"
     });
-    
+
+
     var util = require("util"),
+        config = require("./lib/config").getConfig(),
         generator = require("./lib/generator"),
         logger = require("./lib/logger"),
         Q = require("q"),
@@ -146,6 +148,8 @@
             options.password = argv.password;
         }
         
+        options.config = config;
+
         theGenerator.start(options).done(
             function () {
                 logger.log("init", "app", "Generator started!", null);

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+    
+    var resolve = require("path").resolve,
+        home = process.env[(process.platform === "win32") ? "USERPROFILE" : "HOME"],
+        cwd = process.cwd(),
+        configLocations = [ // locations are listed from lowest to highest precedence
+            resolve(home, ".generator.json"),
+            resolve(home, ".generator.js"),
+            resolve(home, "generator.json"),
+            resolve(home, "generator.js"),
+            resolve(cwd,  ".generator.json"),
+            resolve(cwd,  ".generator.js"),
+            resolve(cwd,  "generator.json"),
+            resolve(cwd,  "generator.js")
+        ],
+        config = null;
+
+    // Does a merge of the properties of src into dest. Dest is modified and returned (though the
+    // return value can be safely ignored). If src and dest are not both objects, then dest is not
+    // modified.
+    //
+    // Important: This is *not* a deep copy and should not be treated as such. Sub-objects of
+    // src may get added to dest by reference. So, changing sub-properties of src after calling merge
+    // may change dest.
+    function merge(dest, src) {
+        if (dest instanceof Object && src instanceof Object) {
+            Object.keys(src).forEach(function (key) {
+                if (!dest[key] || !(dest[key] instanceof Object && src[key] instanceof Object)) {
+                    dest[key] = src[key];
+                } else { // both objects, so merge
+                    merge(dest[key], src[key]);
+                }
+            });
+        }
+        return dest;
+    }
+
+    function getConfig() {
+        if (!config) {
+            config = {};
+            configLocations.forEach(function (loc) {
+                try {
+                    var addition = require(loc);
+                    if (addition && addition instanceof Object) {
+                        merge(config, addition);
+                    }
+                    console.log("Parsed config file: " + loc);
+                } catch (e) {
+                    // do nothing
+                }
+            });
+        }
+        return config;
+    }
+
+    exports.getConfig = getConfig;
+
+    // for unit tests
+    exports._merge = merge;
+
+}());

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -83,6 +83,8 @@
     
     Generator.prototype.start = function (options) {
         var self = this;
+
+        self._config = options.config || {};
         
         function connectToPhotoshop() {
             var connectionDeferred = Q.defer();
@@ -542,9 +544,13 @@
             throw new Error("Argument error: specified path is not a directory");
         } else {
             try {
-                var plugin = require(absolutePath);
-                plugin.init(this);
-                this.publish("generator.info.pluginLoaded", absolutePath);
+                var pluginPackage = require(resolve(absolutePath, "package.json"));
+                if (pluginPackage && pluginPackage.name) {
+                    // TODO: Also check that plugin is compatible with this version of Generator
+                    var plugin = require(absolutePath);
+                    plugin.init(this, this._config[pluginPackage.name] || {});
+                    this.publish("generator.info.pluginLoaded", absolutePath);
+                }
             } catch (e) {
                 throw new Error("Could not load plugin at path '" + absolutePath + "' " + e.message);
             }

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var merge = require("../lib/config")._merge;
+
+    exports.testMerge = function (test) {
+        test.deepEqual(
+            merge({}, {a : 1}),
+            {a : 1},
+            "merge into empty"
+        );
+
+        test.deepEqual(
+            merge({a : 1}, {}),
+            {a : 1},
+            "merge empty into filled"
+        );
+
+        test.deepEqual(
+            merge({a : 1}, {a : 2}),
+            {a : 2},
+            "merge overwrite"
+        );
+
+        test.deepEqual(
+            merge({a : 1}, {a : {b : 2}}),
+            {a : {b : 2}},
+            "merge overwrite primitive with object"
+        );
+
+        test.deepEqual(
+            merge({a : {b : 1}}, {a : 2}),
+            {a : 2},
+            "merge overwrite object with primitive"
+        );
+
+        test.deepEqual(
+            merge({a : {b : 1}}, {a : {c : 2}}),
+            {a : {b : 1, c : 2}},
+            "merge recursive"
+        );
+
+        test.deepEqual(
+            merge({a : {b : 1, c: 3}}, {a : {b : 2, d : 4}}),
+            {a : {b : 2, c : 3, d : 4}},
+            "merge recursive with overwrite"
+        );
+
+        test.deepEqual(
+            merge(1, {a : {b : 2, d : 4}}),
+            1,
+            "merge into primitive"
+        );
+
+        test.deepEqual(
+            merge({a : 1}, 1),
+            {a : 1},
+            "merging in primitive is noop"
+        );
+
+        var a = {a : 1},
+            b = {b : 2},
+            c = merge(a, b);
+            
+        test.strictEqual(a, c, "src modified in place");
+        test.deepEqual(a, {a : 1, b : 2}, "src modified in place correctly");
+
+        test.done();
+
+    };
+}());


### PR DESCRIPTION
Adds a simple config file parser. Config files are JSON files (or js files that export a single object) of the following format:

``` json
{
    "generator-plugin-name-1" : {
        "option-1" : true,
        "option-2" : false
    },
    "generator-plugin-name-2" : {
        "option-3" : { "hoo" : "hah" },
        "option-4" : 42
    }  
}
```

Config files can be in either the user's home directory or the current working directory. They can have the name "generator.json", "generator.js", ".generator.json", or ".generator.js". All found config files are merged. Files in the current working directory take precedence.

The config options for a plugin are passed as a second argument to the `init` call
