### PR TITLE
Allow specifying a single plugin as the plugin folder

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -32,8 +32,9 @@
     
     var _instanceCount = 0;
     
-    var MENU_STATE_KEY_PREFIX = "GENERATOR_MENU-",
-        PHOTOSHOP_EVENT_PREFIX = "PHOTOSHOP-EVENT-";
+    var MENU_STATE_KEY_PREFIX = "GENERATOR-MENU-",
+        PHOTOSHOP_EVENT_PREFIX = "PHOTOSHOP-EVENT-",
+        PLUGIN_KEY_PREFIX = "PLUGIN-";
 
     var REQUEST_TIMEOUT = 20000; // milliseconds. TODO: Make configurable
     
@@ -64,26 +65,12 @@
         });
     }
 
-    function folderIsAPlugin(pluginFolder) {
-        var resolve = require("path").resolve,
-            fs = require("fs");
-        
-        try {
-            return fs.existsSync(pluginFolder) &&
-                fs.statSync(pluginFolder).isDirectory() &&
-                fs.existsSync(resolve(pluginFolder, "package.json"));
-        } catch (e) {
-            console.warn("Error when testing whether '%s' is a plugin folder: %s", pluginFolder, e.stack);
-        }
-        
-        return false;
-    }
-
     function Generator() {
         if (!this instanceof Generator) {
             return new Generator();
         }
         // TODO: declare these as prototype properties and document types
+        this._plugins = {};
         this._photoshop = null;
         this._instanceID = _instanceCount++;
         this._jsMessageDeferreds = [];
@@ -97,7 +84,7 @@
     function createGenerator() {
         return new Generator();
     }
-    
+
     Generator.prototype.start = function (options) {
         var self = this;
 
@@ -585,69 +572,55 @@
     Generator.prototype.isConnected = function () {
         return (this._photoshop && this._photoshop.isConnected());
     };
-        
-    Generator.prototype.loadPlugin = function (directory) {
-        var resolve = require("path").resolve,
-            fs = require("fs");
-
-        var absolutePath = resolve(process.cwd(), directory);
-        
-        if (!fs.statSync(absolutePath).isDirectory()) {
-            throw new Error("Argument error: specified path is not a directory");
-        } else {
-            try {
-                var pluginPackage = require(resolve(absolutePath, "package.json"));
-                if (pluginPackage && pluginPackage.name) {
-                    // TODO: Also check that plugin is compatible with this version of Generator
-                    var plugin = require(absolutePath);
-                    plugin.init(this, this._config[pluginPackage.name] || {});
-                    console.log("Plugin loaded", absolutePath);
-                }
-            } catch (e) {
-                throw new Error("Could not load plugin at path '" + absolutePath + "' " + e.message);
-            }
-        }
-    };
     
-    Generator.prototype.loadAllPluginsInDirectory = function (directory) {
-        // relative paths are resolved relative to generator core directory
-        var resolve = require("path").resolve,
-            fs = require("fs"),
-            self = this;
+    Generator.prototype.loadPlugin = function (directory) {
+        var fs = require("fs"),
+            resolve = require("path").resolve,
+            metadata = null;
         
-        var absolutePath = resolve(process.cwd(), directory);
-        
-        console.log("Loading plugins from", absolutePath);
-        
-        if (!fs.statSync(absolutePath).isDirectory()) {
+        // Make sure a directory was specified
+        if (!fs.statSync(directory).isDirectory()) {
             throw new Error("Argument error: specified path is not a directory");
         }
 
-        var plugins;
-
-        if (folderIsAPlugin(absolutePath)) {
-            plugins = [absolutePath];
-        } else {
-            try {
-                plugins = fs.readdirSync(absolutePath)
-                    .map(function (folderName) { return resolve(absolutePath, folderName); })
-                    .filter(folderIsAPlugin);
-            } catch (e) {
-                console.error("Error when listing directory '%s': %s", absolutePath, e.stack);
-            }
+        // Check for metadata and name uniqueness
+        try {
+            metadata = require(resolve(directory, "package.json"));
+        } catch (metadataError) {
+            throw new Error("Error reading metadata for plugin at path '" + directory + "': " + metadataError.message);
         }
 
-        if (plugins) {
-            plugins.forEach(function (pluginFolder) {
-                try {
-                    self.loadPlugin(pluginFolder);
-                } catch (e) {
-                    console.error("Error loading plugin '%s': %s", pluginFolder, e.stack);
-                }
-            });
+        if (!(metadata && metadata.name && typeof metadata.name === "string")) {
+            throw new Error("Invalid metadata for plugin at path '" + directory +
+                "' (plugins must have a valid package.json file with 'name' property): " +
+                JSON.stringify(metadata));
+        } else if (this._plugins[PLUGIN_KEY_PREFIX + metadata.name]) {
+            throw new Error("Attempted to load a plugin with a name that is already used. Path: '" +
+                directory + "', name: '" + metadata.name + "'");
+        }
+        // TODO: Also check that plugin is compatible with this version of Generator
+
+        // Do the actual plugin load
+        try {
+            // NOTE: We don't need to worry about accidentally requiring the same plugin twice.
+            // If the user did try to load it twice, require's caching would return the same
+            // package.json both times (even if the package.json changed on disk), and so
+            // we'd get the same name both times, and bail in the "if" branch above.
+            var plugin = require(directory),
+                config = this._config[metadata.name] || {};
+
+            plugin.init(this, config);
+            this._plugins[PLUGIN_KEY_PREFIX + metadata.name] = {
+                metadata: metadata,
+                plugin: plugin,
+                config: config
+            };
+            console.log("Plugin loaded: %s", metadata.name);
+        } catch (loadError) {
+            throw new Error("Could not load plugin at path '" + directory + "': " + loadError.message);
         }
     };
-        
+            
     exports.Generator         = Generator;
     exports.createGenerator   = createGenerator;
     exports._escapePluginId   = escapePluginId;


### PR DESCRIPTION
Also, identify plugin folders by checking whether they contain a package.json, rather than requiring the folder to be named <name>.generate

Fixes #51.
