### PR TITLE
add optional parameter to getDocumentInfo to override flags

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -269,9 +269,18 @@
     /**
      * Get information about a document.
      * To find out about the current document, leave documentId empty.
-     * @params {?integer} documentId Optional document ID
+     * @param {?integer} documentId Optional document ID
+     * @param {?Object.<string, boolean>} flags Optional override of default flags for
+     *   document info request. The optional flags and their default values are:
+     *          compInfo:           true
+     *          imageInfo:          true
+     *          layerInfo:          true
+     *          expandSmartObjects: false
+     *          getTextStyles:      true
+     *          selectedLayers:     true
+     *          getCompSettings:    true
      */
-    Generator.prototype.getDocumentInfo = function (documentId) {
+    Generator.prototype.getDocumentInfo = function (documentId, flags) {
         var params = {
             documentId: documentId,
             flags: {
@@ -284,6 +293,17 @@
                 getCompSettings:    true
             }
         };
+
+        if (flags) {
+            Object.keys(params.flags).forEach(function (key) {
+                if (flags.hasOwnProperty(key)) {
+                    params.flags[key] = flags[key];
+                }
+            });
+        }
+
+        console.log("Getting document info with these params: %j", params);
+
         return this.evaluateJSXFile("./jsx/getDocumentInfo.jsx", params);
     };
 


### PR DESCRIPTION
Allows you to override the default flags for getDocumentInfo. So, you can request a minimal set of document info with something like:

``` javascript
g.getDocumentInfo(null, {
    compInfo:           false,
    imageInfo:          false,
    layerInfo:          false,
    expandSmartObjects: false,
    getTextStyles:      false,
    selectedLayers:     false,
    getCompSettings:    false
});
```

cc @anirudhsasikumar 
