### PR TITLE
Support the bounds parameter that allows sending bounds with the pixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -543,11 +543,12 @@
             params          = {
                 documentId: documentId,
                 layerId:    layerId,
-                boundsOnly: settings.boundsOnly,
                 inputRect:  settings.inputRect,
                 outputRect: settings.outputRect,
                 scaleX:     settings.scaleX || 1,
-                scaleY:     settings.scaleY || 1
+                scaleY:     settings.scaleY || 1,
+                bounds:     true,
+                boundsOnly: settings.boundsOnly
             };
 
         rejectAfter(jsDeferred, REQUEST_TIMEOUT);
@@ -578,6 +579,9 @@
                 function (vals) {
                     var pixmapBuffer = vals[1];
                     var pixmap = xpm.Pixmap(pixmapBuffer);
+                    if (vals[0] && vals[0].bounds) {
+                        pixmap.bounds = vals[0].bounds;
+                    }
                     overallDeferred.resolve(pixmap);
                 }, function (err) {
                     overallDeferred.reject(err);

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -82,6 +82,8 @@ actionDescriptor.putEnumerated(
 
 if (params.boundsOnly) {
     actionDescriptor.putBoolean(stringIDToTypeID("boundsOnly"), params.boundsOnly);
+} else if (params.bounds) {
+    actionDescriptor.putBoolean(stringIDToTypeID("bounds"), params.bounds);
 }
 
 executeAction(stringIDToTypeID("sendLayerThumbnailToNetworkClient"), actionDescriptor, DialogModes.NO);


### PR DESCRIPTION
Fixes #86.

Realized too late that this wouldn't be necessary to add now. But, actually, maybe it will be.
