### PR TITLE
When loading plugins, adds a check of the package.json config variable "generator-core-version"

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -29,7 +29,9 @@
         photoshop = require("./photoshop"),
         util = require("util"),
         xpm = require("./xpm"),
-        versions = require("./versions");
+        semver = require("semver"),
+        versions = require("./versions"),
+        packageConfig = require("../package.json");
     
     var _instanceCount = 0;
     
@@ -39,6 +41,8 @@
 
     var REQUEST_TIMEOUT = 20000; // milliseconds. TODO: Make configurable
     
+    var PLUGIN_INCOMPATIBLE_MESSAGE = "$$$/Generator/NotCompatibleString";
+
     function rejectAfter(deferred, timeout) {
         var rejectTimer = setTimeout(function () {
             rejectTimer = null;
@@ -220,6 +224,10 @@
         
         evaluationDeferred.promise.finally(function () { delete self._jsMessageDeferreds[id]; });
         return evaluationDeferred.promise;
+    };
+
+    Generator.prototype.alert = function (message, stringReplacements) {
+        this.evaluateJSXFile("./jsx/alert.jsx", { message: message, replacements: stringReplacements });
     };
 
     Generator.prototype.getPhotoshopPath = function () {
@@ -610,7 +618,14 @@
     Generator.prototype.loadPlugin = function (directory) {
         var fs = require("fs"),
             resolve = require("path").resolve,
-            metadata = null;
+            metadata = null,
+            self = this;
+
+        function handleIncompatiblePlugin(metadata) {
+            self.alert(PLUGIN_INCOMPATIBLE_MESSAGE, [metadata.name]);
+            // TODO: Record that we have given an alert for this plugin, and only
+            // alert if we've never alerted for it before.
+        }
         
         // Make sure a directory was specified
         if (!fs.statSync(directory).isDirectory()) {
@@ -628,11 +643,16 @@
             throw new Error("Invalid metadata for plugin at path '" + directory +
                 "' (plugins must have a valid package.json file with 'name' property): " +
                 JSON.stringify(metadata));
-        } else if (this._plugins[PLUGIN_KEY_PREFIX + metadata.name]) {
+        } else if (self._plugins[PLUGIN_KEY_PREFIX + metadata.name]) {
             throw new Error("Attempted to load a plugin with a name that is already used. Path: '" +
                 directory + "', name: '" + metadata.name + "'");
+        } else if (metadata["generator-core-version"] &&
+            !semver.satisfies(packageConfig.version, metadata["generator-core-version"])) {
+            handleIncompatiblePlugin(metadata);
+            throw new Error("Attempted to load a plugin '%s' that is incompatible with this version of " +
+                " generator-core. generator-core version: %s, plugin compatibility: %s",
+                metadata.name, packageConfig.version, metadata["generator-core-version"]);
         }
-        // TODO: Also check that plugin is compatible with this version of Generator
 
         // Do the actual plugin load
         try {
@@ -645,10 +665,10 @@
             // package.json both times (even if the package.json changed on disk), and so
             // we'd get the same name both times, and bail in the "if" branch above.
             var plugin = require(directory),
-                config = this._config[metadata.name] || {};
+                config = self._config[metadata.name] || {};
 
             plugin.init(this, config);
-            this._plugins[PLUGIN_KEY_PREFIX + metadata.name] = {
+            self._plugins[PLUGIN_KEY_PREFIX + metadata.name] = {
                 metadata: metadata,
                 plugin: plugin,
                 config: config

--- a/lib/jsx/alert.jsx
+++ b/lib/jsx/alert.jsx
@@ -1,0 +1,25 @@
+/*global params, localize, alert */
+
+// Required params:
+//   - message - message to send to the user
+// Optional params:
+//   - replacements - array of strings that get substituted for "^0", "^1", etc.
+//     in the message. Substitutions are done by index into the array.
+
+var theMessage, i;
+
+if (params.message) {
+    if (params.message.indexOf("$$$") === 0) { // PS-localizable strings start with "$$$"
+        theMessage = localize(params.message);
+    } else {
+        theMessage = params.message;
+    }
+
+    if (params.replacements) {
+        for (i = 0; i < params.replacements.length; i++) {
+            theMessage = theMessage.replace(new RegExp("\\^" + i, "g"), params.replacements[i]);
+        }
+    }
+
+    alert(theMessage);
+}


### PR DESCRIPTION
If this value is present, and also not compatible with the current version of generator-core (read from package.json), then Generator will not load the plugin. Instead, an alert will be shown in Photoshop.

For a plugin to implement this, its package.json should look something like:

``` javascript
{
  "name": "generator-assets",
  "generator-core-version": "~1"
  // other stuff
}
```

Fixes #79
