### PR TITLE
Offer quad-based transforms for scaling

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -505,8 +505,18 @@
      * @params {!integer} layerId Layer ID
      * @params {!Object}  settings An object with params to request the pixmap
      * @params {?boolean} settings.boundsOnly Whether to return a JSON object with bounds rather than the pixmap
+     * @params {?Object}  settings.inputRect  Rectangular part of the document to use (usually the layer's bounds)
+     * @params {?Object}  settings.outputRect Rectangle into which the the layer should fit
      * @params {?float}   settings.scaleX     The factor by which to scale the image horizontally (1.0 for 100%)
-     * @params {?float}   settings.scaleY     The factor by which to scale the image vertically (1.0 for 100%)
+     * @params {?float}   settings.scaleX     The factor by which to scale the image vertically (1.0 for 100%)
+     * @params {!float}   settings.inputRect.left    Distance of the rectangle's left side from the doc's left side
+     * @params {!float}   settings.inputRect.top     Distance of the rectangle's top from the doc's top
+     * @params {!float}   settings.inputRect.right   Distance of the rectangle's right side from the doc's left side
+     * @params {!float}   settings.inputRect.bottom  Distance of the rectangle's bottom from the doc's top
+     * @params {!float}   settings.outputRect.left   Distance of the rectangle's left side from the doc's left side
+     * @params {!float}   settings.outputRect.top    Distance of the rectangle's top from the doc's top
+     * @params {!float}   settings.outputRect.right  Distance of the rectangle's right side from the doc's left side
+     * @params {!float}   settings.outputRect.bottom Distance of the rectangle's bottom from the doc's top
      */
     Generator.prototype.getPixmap = function (documentId, layerId, settings) {
         if (arguments.length !== 3) {
@@ -520,9 +530,11 @@
             params          = {
                 documentId: documentId,
                 layerId:    layerId,
+                boundsOnly: settings.boundsOnly,
+                inputRect:  settings.inputRect,
+                outputRect: settings.outputRect,
                 scaleX:     settings.scaleX || 1,
-                scaleY:     settings.scaleY || 1,
-                boundsOnly: settings.boundsOnly
+                scaleY:     settings.scaleY || 1
             };
 
         rejectAfter(jsDeferred, REQUEST_TIMEOUT);

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -1,9 +1,14 @@
-/*global params, stringIDToTypeID, ActionDescriptor, executeAction, DialogModes */
+/*global params, stringIDToTypeID, charIDToTypeID,
+    ActionDescriptor, ActionList, executeAction, DialogModes */
 
 // Required params:
 //   - documentId: The ID of the document requested
 //   - layerId:    The ID of the layer requested
 //   - boundsOnly: Whether to only request the bounds fo the pixmap
+//   Either use absolute scaling by specifying which part of the doc should be transformed into what shape:
+//   - inputRect:  { left: ..., top: ..., right: ..., bottom: ... }
+//   - outputRect: { left: ..., top: ..., right: ..., bottom: ... }
+//   Or use relative scaling by specifying horizontal and vertical factors:
 //   - scaleX:     The x-dimension scale factor (e.g. 0.5 for half size) for the output pixmap
 //   - scaleY:     The y-dimension scale factor (e.g. 0.5 for half size) for the output pixmap
 
@@ -13,13 +18,54 @@ var actionDescriptor = new ActionDescriptor(),
     transform;
 
 // Add a transform if necessary
-if (params.scaleX && params.scaleY && (params.scaleX !== 1 || params.scaleY !== 1)) {
+if (params.inputRect && params.outputRect) {
     transform = new ActionDescriptor();
+
+    // The part of the document to use
+    var inputRect   = params.inputRect,
+        psInputRect = new ActionList();
+
+    psInputRect.putUnitDouble(charIDToTypeID("#Pxl"), inputRect.left);
+    psInputRect.putUnitDouble(charIDToTypeID("#Pxl"), inputRect.top);
+    
+    psInputRect.putUnitDouble(charIDToTypeID("#Pxl"), inputRect.right);
+    psInputRect.putUnitDouble(charIDToTypeID("#Pxl"), inputRect.bottom);
+
+    transform.putList(stringIDToTypeID("rectangle"), psInputRect);
+
+    // Where to move the four corners
+    var outputRect      = params.outputRect,
+        psOutputCorners = new ActionList();
+
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.left);
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.top);
+    
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.right);
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.top);
+    
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.right);
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.bottom);
+    
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.left);
+    psOutputCorners.putUnitDouble(charIDToTypeID("#Pxl"), outputRect.bottom);
+
+    transform.putList(stringIDToTypeID("quadrilateral"), psOutputCorners);
+
+    // Absolute scaling may not keep the aspect ratio intact, in which case effects
+    // cannot be scaled. To be consistent, turn it off for all of absolute scaling
+    // transform.putBoolean(stringIDToTypeID("scaleStyles"), false);
+}
+else if (params.scaleX && params.scaleY && (params.scaleX !== 1 || params.scaleY !== 1)) {
+    transform = new ActionDescriptor();
+    
     transform.putDouble(stringIDToTypeID("width"), params.scaleX * 100);
     transform.putDouble(stringIDToTypeID("height"), params.scaleY * 100);
     transform.putEnumerated(stringIDToTypeID("interpolation"),
                             stringIDToTypeID("interpolationType"),
                             stringIDToTypeID("automaticInterpolation"));
+}
+
+if (transform) {
     actionDescriptor.putObject(stringIDToTypeID("transform"), stringIDToTypeID("transform"), transform);
 }
 


### PR DESCRIPTION
We may end up using this other way to request images of a certain size. It's certainly something that the bounds test plugin is about to use soon, so it would be convenient to have in master. Otherwise, to use the bounds tester, you have to switch to this branch.
