### PR TITLE
add ability to configure log output and levels

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,12 +24,14 @@
 (function () {
     "use strict";
     
-    require("./lib/stdlog").setup({
+    var stdlog = require("./lib/stdlog");
+
+    stdlog.setup({
         vendor:      "Adobe",
         application: "Adobe Photoshop CC",
-        module:      "Generator"
+        module:      "Generator",
+        level:       "error"
     });
-
 
     var util = require("util"),
         config = require("./lib/config").getConfig(),
@@ -37,6 +39,7 @@
         Q = require("q"),
         optimist = require("optimist");
 
+    stdlog.processConfig(config.logging);
 
     var DEBUG_ON_LAUNCH = false;
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -108,7 +108,7 @@
             });
 
             self._photoshop.on("error", function (err) {
-                console.error("Photoshop error", err);
+                console.warn("Photoshop error", err);
                 // If the error does refers to a specific command we ran, reject the corresponding deferred
                 if (err.body && err.id) {
                     if (self._jsMessageDeferreds[err.id]) {
@@ -119,7 +119,7 @@
             });
 
             self._photoshop.on("communicationsError", function (err, rawMessage) {
-                console.error("photoshop communcations error: %j", {error: err, rawMessage: rawMessage});
+                console.warn("photoshop communcations error: %j", {error: err, rawMessage: rawMessage});
             });
 
             self._photoshop.on("message", function (messageID, parsedValue) { // ,rawMessage)
@@ -158,7 +158,7 @@
                         self._photoshop._applicationPath = p;
                     },
                     function (err) { // error
-                        console.error("Error retrieving Photoshop path", err);
+                        console.warn("Error retrieving Photoshop path", err);
                     }
                 );
             })
@@ -405,7 +405,7 @@
                 return JSON.parse(settings.json);
             }
             catch (e) {
-                console.error("Could not parse" + settings.json + ": " + e.stack);
+                console.warn("Could not parse" + settings.json + ": " + e.stack);
             }
         }
         return settings;
@@ -473,7 +473,7 @@
         self.subscribeToPhotoshopEvents(event).done(function () {
             console.log("Finished subscribe to photoshop event %s", event);
         }, function () {
-            console.error("Failed to subscribe to photoshop event %s", event);
+            console.warn("Failed to subscribe to photoshop event %s", event);
             self.removePhotoshopEventListener(event, listener);
         });
 

--- a/lib/stdlog.js
+++ b/lib/stdlog.js
@@ -1,12 +1,173 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*
+ * NOTE: A portion of this logger code shares implementation details with
+ * the logger in the "node-core" of Brackets. That logger was also written
+ * by me (Joel Brandt) while employed by Adobe and is also licensed under
+ * the same license (MIT).
+ */
+
 (function () {
     "use strict";
 
     var fs      = require("fs"),
-        resolve = require("path").resolve;
+        resolve = require("path").resolve,
+        util         = require("util");
 
 
-    var _logDir;
+    // Constants
+    // =========
+    var LOG_PRECEDENCE = ["log", "dir", "info", "warn", "error"],
+        DEFAULT_LOG_LEVEL = "error";
 
+    // Logger class
+    // ============
+
+    /** 
+     * @constructor
+     * The Logger module is a singleton object used for logging.
+     * Logger inherits from the EventEmitter class and exports itself
+     * as the module.
+     */
+    function Logger(level) {
+        if (!(this instanceof Logger)) {
+            return new Logger();
+        }
+        this.setLogLevel(level || DEFAULT_LOG_LEVEL);
+    }
+    
+    // Private methods
+    // ---------------
+
+    /**
+     * @private
+     * Helper function for logging functions. Handles string formatting.
+     * @param {string} level Log level ("log", "info", etc.)
+     * @param {Array.<Object>} Array of objects for logging. Works identically
+     *    to how objects can be passed to console.log. Uses util.format to
+     *    format into a single string.
+     */
+    Logger.prototype._logAtLevel = function (level, args) {
+        if (LOG_PRECEDENCE.indexOf(level) >= this._logLevel) {
+            var message = util.format.apply(null, args),
+                timestamp = new Date(),
+                prefix = "";
+
+            try {
+                prefix = "[" + level + ": " + timestamp.toLocaleTimeString() + "] ";
+            } catch (prefixError) { }
+
+            try {
+                if (level === "error") {
+                    process.stderr.write(prefix + message + "\n");
+                    process.stderr.write((new Error()).stack + "\n");
+                } else {
+                    process.stdout.write(prefix + message + "\n");
+                }
+            } catch (outputError) { }
+        }
+    };
+
+    // Public interface
+    // ----------------
+    
+    /**
+     * Set the level at which log calls are printed to standard output
+     * @param {string} level One of log", "dir", "info", "warn", "error"
+     */
+    Logger.prototype.setLogLevel = function (level) {
+        // If a level is not specified or does not match a string
+        // in the precedence list, then _logLevel will be set to -1,
+        // which will result in everything being logged (which is 
+        // the desired behavior)
+        this._logLevel = LOG_PRECEDENCE.indexOf(level);
+    };
+
+    /**
+     * Log a "log" message
+     * @param {...Object} log arguments as in console.log etc.
+     *    First parameter can be a "format" string.
+     */
+    Logger.prototype.log = function () { this._logAtLevel("log", arguments); };
+
+    /**
+     * Log an "info" message
+     * @param {...Object} log arguments as in console.log etc.
+     *    First parameter can be a "format" string.
+     */
+    Logger.prototype.info = function () { this._logAtLevel("info", arguments); };
+
+    /**
+     * Log a "warn" message
+     * @param {...Object} log arguments as in console.log etc.
+     *    First parameter can be a "format" string.
+     */
+    Logger.prototype.warn = function () { this._logAtLevel("warn", arguments); };
+
+    /**
+     * Log an "error" message
+     * @param {...Object} log arguments as in console.log etc.
+     *    First parameter can be a "format" string.
+     */
+    Logger.prototype.error = function () { this._logAtLevel("error", arguments); };
+
+    /**
+     * Log a "dir" message
+     * @param {...Object} log arguments as in console.dir
+     *    Note that (just like console.dir) this does NOT do string
+     *    formatting using the first argument.
+     */
+    Logger.prototype.dir = function () {
+        // dir does not do optional string formatting
+        var args = Array.prototype.slice.call(arguments, 0);
+        args.unshift("%j");
+        this._logAtLevel("dir", args);
+    };
+    
+    /**
+     * Remaps the console.log, etc. functions to the logging functions
+     * defined in this module. Useful so that modules can simply call
+     * console.log to call into this Logger (since client doesn't have)
+     * access to stdout.
+     */
+    Logger.prototype.remapConsole = function () {
+        // Reassign logging functions to our logger
+        // NOTE: console.timeEnd uses console.log and console.trace uses
+        // console.error, so we don't need to change it explicitly
+        console.log   = this.log.bind(this);
+        console.info  = this.info.bind(this);
+        console.warn  = this.warn.bind(this);
+        console.error = this.error.bind(this);
+        console.dir   = this.dir.bind(this);
+    };
+        
+    // Helper functions
+    // ================
+
+    var _logFilePaths = [],
+        _logger = null,
+        _logDir = null;
 
     // logs/_exceptions.log
     
@@ -40,7 +201,6 @@
     // Use tail -F logs/_latest.log to see the latest output
     // The timestamped files can more easily be sent to the developers
 
-    var logFilePaths = [];
 
     function padLeft(value, length, padding) {
         while (value.length < length) {
@@ -63,7 +223,7 @@
     }
 
     function writeToLog(data) {
-        logFilePaths.forEach(function (path) {
+        _logFilePaths.forEach(function (path) {
             try {
                 fs.appendFileSync(path, data);
             } catch (e) {
@@ -76,12 +236,16 @@
         var write = stream.write;
         
         stream.write = function (data) {
-            write.apply(this, arguments);
+            try {
+                write.apply(this, arguments);
+            } catch (streamWriteError) { }
             
-            data = String(data);
-            if (colorFunction) {
-                data = colorFunction(String(data));
-            }
+            try {
+                data = String(data);
+                if (colorFunction) {
+                    data = colorFunction(String(data));
+                }
+            } catch (colorError) { }
 
             writeToLog(data);
         };
@@ -121,6 +285,9 @@
     }
 
     function setup(settings) {
+        _logger = new Logger(settings.level);
+        _logger.remapConsole();
+
         try {
             // Create the log file directory
             _logDir = createDirectoryWithElements(getLogDirectoryElements(settings));
@@ -138,7 +305,7 @@
         // Create one that is easy to use with tail (_latest.log)
         // Create another that is easy to attach to emails (timestamped)
         var _latestLogFile      = resolve(_logDir, "_latest.log");
-        var _timeStampedLogFile = resolve(_logDir, timeString() + ".log");
+        
         
         // Delete an existing latest log file 
         try {
@@ -150,7 +317,7 @@
             console.error(e);
         }
         
-        logFilePaths.push(_latestLogFile, _timeStampedLogFile);
+        _logFilePaths.push(_latestLogFile);
 
         logStream(process.stdout);
         // Print output via STDERR in red
@@ -161,5 +328,42 @@
         writeToLog("Log file created on " + new Date() + "\n\n");
     }
 
+    function setLogLevel(level) {
+        if (_logger) {
+            _logger.setLogLevel(level);
+        }
+    }
+
+    function addLogFile(filename) {
+        _logFilePaths.push(resolve(_logDir, filename));
+    }
+
+    function addTimeStampedLogFile(directory) {
+        if (!directory) {
+            directory = ".";
+        }
+        var _timeStampedLogFile = resolve(_logDir, directory, timeString() + ".log");
+        _logFilePaths.push(_timeStampedLogFile);
+    }
+
+    function processConfig(config) {
+        if (config) {
+            if (config.level) {
+                setLogLevel(config.level);
+            }
+            if (config.keep) {
+                addTimeStampedLogFile();
+            }
+            if (config.logfile) {
+                addLogFile(config.logfile);
+            }
+        }
+    }
+
     exports.setup = setup;
+    exports.setLogLevel = setLogLevel;
+    exports.addLogFile = addLogFile;
+    exports.addTimeStampedLogFile = addTimeStampedLogFile;
+    exports.processConfig = processConfig;
+
 }());

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -52,14 +52,14 @@
                 refFile = resolve(gitDir, ref);
             
             if (!match) {
-                console.error("%s Could not interpret HEAD file with contents %j", prefix, head);
+                console.warn("%s Could not interpret HEAD file with contents %j", prefix, head);
                 return;
             }
 
             var message = "Git branch " + branch;
             
             if (!fs.existsSync(refFile)) {
-                console.error("%s Git ref file %j does not exist", prefix, refFile);
+                console.warn("%s Git ref file %j does not exist", prefix, refFile);
             } else {
                 message += " @ " + fs.readFileSync(refFile).toString().trim();
             }
@@ -68,7 +68,7 @@
                 
         }
         catch (e) {
-            console.error("%s Error while reading Git information: %s", prefix, e.stack);
+            console.warn("%s Error while reading Git information: %s", prefix, e.stack);
         }
     }
 


### PR DESCRIPTION
This pull requests does a number of things:
- It overrides console.log/info/warn/error/dir to (optionally) supress output
- Provides a way to set log levels that are actually writted to stdout/stderr
- Provides a way to configure the logger from a generator config file.

The config options go in a "logging" section of the config file. The options are:
- **keep** -- boolean specifying whether to also create a timestamped log in the log dir (in addition to _latest) -- defaults to false
- **level** -- one of "log", "dir", "info", "warn", "error", sets the log level -- defaults to "error"
- **logfile** -- optional path to an additional log file, resolved against the default log dir if a relative path -- defaults to null

Here's some simple JS that can be used to test this (place in same dir as generator-core's app.js):

``` javascript
(function () {
    "use strict";

    var stdlog = require("./lib/stdlog");

    stdlog.setup({
        vendor:      "Adobe",
        application: "Adobe Photoshop CC",
        module:      "Generator",
        level:       "error"
    });

    var config = require("./lib/config").getConfig();

    stdlog.processConfig(config.logging);

    console.log("a log");
    console.info("an info");
    console.warn("a warn");
    console.error("an error");
    console.dir({a : "dir"});

    console.log("setting log level to warn");
    stdlog.setLogLevel("warn");

    console.log("another log -- should not appear");
    console.info("another info -- should not appear");
    console.warn("another warn");
    console.error("another error");
    console.dir({a : "dir that should not appear"});

}());
```

And, here's a simple config file (name generator.json in same dir as app.js):

``` json
{
    "logging" : {
        "keep" : false,
        "level" : "log",
        "logfile" : "/Users/jbrandt/Desktop/mylog.txt"
    }
}
```
