### PR TITLE
Ignore invisible adjustment layers when generating a pixmap

### DIFF
--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -79,6 +79,11 @@ actionDescriptor.putEnumerated(
     stringIDToTypeID("includeLayers"),
     stringIDToTypeID("includeNone")
 );
+actionDescriptor.putEnumerated(
+    stringIDToTypeID("includeAdjustors"),
+    stringIDToTypeID("includeLayers"),
+    stringIDToTypeID("includeVisible")
+);
 
 if (params.boundsOnly) {
     actionDescriptor.putBoolean(stringIDToTypeID("boundsOnly"), params.boundsOnly);


### PR DESCRIPTION
Fixes an issue @timriot found. Note that Photoshop change 921206 changes the default to includeVisible, so this could be considered redundant.

@timothynoel Would you say this is obsolete?
