### PR TITLE
Allow plugins to add padding to generated images

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -108,6 +108,18 @@
         // Read the pixels in RGBA form from STDIN
         args.push("rgba:-");
 
+        var padding = settings.padding;
+        if (padding) {
+            // Calculate the new image size
+            var newWidth  = pixmap.width  + padding.left + padding.right,
+                newHeight = pixmap.height + padding.top  + padding.bottom;
+
+            // Use a transparent background color ("transparent" doesn't work because Colors.xml is missing)
+            args.push("-background", "rgba(0,0,0,0)");
+            // Set the canvas size and position the image inside of it
+            args.push("-extent", newWidth + "x" + newHeight + "-" + padding.left + "-" + padding.top);
+        }
+
         // Define conversions
         args = args.concat(getConvertArgumentsForSettings(settings));
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -619,160 +619,133 @@
         return bounds;
     };
 
-    function diffBounds(bounds, shiftedBounds) {
-        shiftedBounds = shiftedBounds || bounds;
-        return {
-            left:   shiftedBounds.left   - bounds.left,
-            right:  shiftedBounds.right  - bounds.right,
-            top:    shiftedBounds.top    - bounds.top,
-            bottom: shiftedBounds.bottom - bounds.bottom
-        };
-    }
-
     /**
-     * Computes expected bounds based on scaling specified in the layer name
-     * TODO: Document further
+     * Computes the settings for getPixmap to achieve a certain scaling/padding result.
+     *
+     * staticInputBounds is essentially document.layers[i].bounds.
+     * visibleInputBounds is essentially document.layers[i].boundsWithFX or pixmap.bounds (better).
+     * paddedInputBounds is visibleInputBounds extended by document.layers[i].mask.bounds.
+     * paddedInputBounds can therefore extend beyond document.layers[i].mask.bounds (due to effects).
+     *
+     * For a usage example, see the Image Assets plugin (https://github.com/adobe-photoshop/generator-assets).
+     *
+     * @param {!Object} settings How to scale the pixmap (includeing padding)
+     * @param {?float}  settings.width  Requested width of the image
+     * @param {?float}  settings.height Requested height of the image
+     * @param {?float}  settings.scaleX Requested horizontal scaling of the image
+     * @param {?float}  settings.scaleY Requested vertical scaling of the image
+     * @param {!Object<String,float>} staticInputBounds  Bounds for the user-provided content (pixels, shapes)
+     * @param {!Object<String,float>} visibleInputBounds Bounds for the visible content (user-provided + effects)
+     * @param {!Object<String,float>} paddedInputBounds  Bounds for the whole image (visible + padding)
      */
-    Generator.prototype.getPixmapParams = function (settings, innerBounds, outerBounds) {
-        var params       = { boundsOnly: settings.boundsOnly },
-            targetScale  = settings.scale,
-            targetWidth  = settings.width,
-            targetHeight = settings.height,
-            outerWidth   = outerBounds.right - outerBounds.left,
-            outerHeight  = outerBounds.bottom - outerBounds.top,
-            boundsShift  = diffBounds(innerBounds, outerBounds),
-            shiftX       = boundsShift.right - boundsShift.left,
-            shiftY       = boundsShift.bottom - boundsShift.top;
+    Generator.prototype.getPixmapParams = function (settings,
+        staticInputBounds, visibleInputBounds, paddedInputBounds) {
+        
+        // For backwards compatibility
+        paddedInputBounds = paddedInputBounds || visibleInputBounds;
 
-        var expectedWidth,
-            expectedHeight;
-
-        var scaleX,
-            scaleY;
+        var // Scaling settings
+            targetWidth         = settings.width,
+            targetHeight        = settings.height,
+            targetScaleX        = settings.scaleX || settings.scale || 1,
+            targetScaleY        = settings.scaleY || settings.scale || 1,
             
-        if (settings.scaleMode === "relative") {
-            if (targetScale) {
-                scaleX = scaleY = targetScale;
-                expectedWidth  = outerWidth  * scaleX;
-                expectedHeight = outerHeight * scaleY;
-
-                params.scaleX = scaleX;
-                params.scaleY = scaleY;
-            }
-            else if (targetWidth || targetHeight) {
-                if (targetWidth) {
-                    scaleX = targetWidth / outerWidth;
-                    if (!targetHeight) {
-                        scaleY = scaleX;
-                    }
-                }
-                if (targetHeight) {
-                    scaleY = targetHeight / outerHeight;
-                    if (!targetWidth) {
-                        scaleX = scaleY;
-                    }
-                }
-                
-                // In case of non-uniform transforms, the effects are not scaled
-                if (scaleX !== scaleY) {
-                    scaleX = (targetWidth  - shiftX) / (outerWidth  - shiftX);
-                    scaleY = (targetHeight - shiftY) / (outerHeight - shiftY);
-                    expectedWidth  = ((outerWidth  - shiftX) * scaleX) + shiftX;
-                    expectedHeight = ((outerHeight - shiftY) * scaleY) + shiftY;
-                } else {
-                    expectedWidth  = outerWidth  * scaleX;
-                    expectedHeight = outerHeight * scaleY;
-                }
-                
-                params.scaleX = scaleX;
-                params.scaleY = scaleY;
-            }
-            else {
-                expectedWidth  = outerWidth;
-                expectedHeight = outerHeight;
-            }
-        }
-        else if (settings.scaleMode === "absolute" || !settings.scaleMode) {
-            var inputRect,
-                outputRect,
-                left,
-                top;
-
-            if (settings.scale) {
-                targetWidth  = outerWidth  * settings.scale;
-                targetHeight = outerHeight * settings.scale;
-            }
+            // Width and height of the bounds
+            staticInputWidth    = staticInputBounds.right   - staticInputBounds.left,
+            staticInputHeight   = staticInputBounds.bottom  - staticInputBounds.top,
+            visibleInputWidth   = visibleInputBounds.right  - visibleInputBounds.left,
+            visibleInputHeight  = visibleInputBounds.bottom - visibleInputBounds.top,
+            paddedInputWidth    = paddedInputBounds.right   - paddedInputBounds.left,
+            paddedInputHeight   = paddedInputBounds.bottom  - paddedInputBounds.top,
             
-            if (targetWidth || targetHeight) {
-                if (targetWidth) {
-                    scaleX = targetWidth / outerWidth;
-                    if (!targetHeight) {
-                        scaleY = scaleX;
-                        targetHeight = outerHeight * scaleY;
-                    }
-                }
-                if (targetHeight) {
-                    scaleY = targetHeight / outerHeight;
-                    if (!targetWidth) {
-                        scaleX = scaleY;
-                        targetWidth = outerWidth * scaleX;
-                    }
-                }
+            // How much of the width is due to effects
+            effectsInputWidth   = visibleInputWidth  - staticInputWidth,
+            effectsInputHeight  = visibleInputHeight - staticInputHeight,
+            // How much of the width is due to padding (mask)
+            paddingInputWidth   = paddedInputWidth  - visibleInputWidth,
+            paddingInputHeight  = paddedInputHeight - visibleInputHeight,
 
-                // In case of non-uniform transforms, the effects are not scaled
-                if (scaleX !== scaleY) {
-                    left = outerBounds.left - boundsShift.left;
-                    top  = outerBounds.top  - boundsShift.top;
+            // Designated image size
+            paddedOutputWidth   = Math.ceil(targetWidth  || (paddedInputWidth *
+                                    (targetHeight ? (targetHeight / paddedInputHeight) : targetScaleX))),
+            paddedOutputHeight  = Math.ceil(targetHeight || (paddedInputHeight *
+                                    (targetWidth  ? (targetWidth  / paddedInputWidth)  : targetScaleY))),
+            paddedOutputScaleX  = paddedOutputWidth  / paddedInputWidth,
+            paddedOutputScaleY  = paddedOutputHeight / paddedInputHeight,
             
-                    inputRect = {
-                        left:   left,
-                        top:    top,
-                        right:  left + outerWidth  - shiftX,
-                        bottom: top  + outerHeight - shiftY
-                    };
-                    outputRect = {
-                        left:   left,
-                        top:    top,
-                        right:  left + targetWidth  - shiftX,
-                        bottom: top  + targetHeight - shiftY
-                    };
-                    
-                    expectedWidth  = (outputRect.right  - outputRect.left) + shiftX;
-                    expectedHeight = (outputRect.bottom - outputRect.top)  + shiftY;
-                } else {
-                    left = outerBounds.left - boundsShift.left;
-                    top  = outerBounds.top  - boundsShift.top;
+            // Effects are not scaled when the transformation is non-uniform
+            effectsScaled       = paddedOutputScaleX === paddedOutputScaleY,
+
+            // How much to scale everything that can be scaled (static + padding, maybe effects)
+            scaleX              = effectsScaled ? paddedOutputScaleX : paddedOutputScaleX +
+                                    (effectsInputWidth  * (paddedOutputScaleX - 1)) /
+                                    (staticInputWidth  + paddingInputWidth),
+            scaleY              = effectsScaled ? paddedOutputScaleY : paddedOutputScaleY +
+                                    (effectsInputHeight * (paddedOutputScaleY - 1)) /
+                                    (staticInputHeight + paddingInputHeight),
+
+            // The expected size of the pixmap returned by Photoshop (does not include padding)
+            visibleOutputWidth  = effectsScaled ? scaleX * visibleInputWidth :
+                                    scaleX * staticInputWidth + effectsInputWidth,
+            visibleOutputHeight = effectsScaled ? scaleY * visibleInputHeight :
+                                    scaleY * staticInputHeight + effectsInputHeight;
+
+        // The settings for getPixmap
+        return {
+            // For backwards compatibility
+            expectedWidth:  visibleOutputWidth,
+            expectedHeight: visibleOutputHeight,
             
-                    inputRect = {
-                        left:   left,
-                        top:    top,
-                        right:  left + outerWidth  - shiftX,
-                        bottom: top  + outerHeight - shiftY
-                    };
-                    outputRect = {
-                        left:   0,
-                        top:    0,
-                        right:  targetWidth  - shiftX * scaleX,
-                        bottom: targetHeight - shiftY * scaleY
-                    };
-                    
-                    expectedWidth  = (outputRect.right  - outputRect.left) + shiftX * scaleX;
-                    expectedHeight = (outputRect.bottom - outputRect.top)  + shiftY * scaleY;
+            // For now: absolute scaling only
+            inputRect: {
+                left:   staticInputBounds.left,
+                top:    staticInputBounds.top,
+                right:  staticInputBounds.left + staticInputWidth,
+                bottom: staticInputBounds.top  + staticInputHeight
+            },
+            outputRect: {
+                left:   0,
+                top:    0,
+                right:  visibleOutputWidth  - effectsInputWidth  * (effectsScaled ? scaleX : 1),
+                bottom: visibleOutputHeight - effectsInputHeight * (effectsScaled ? scaleY : 1)
+            },
+            
+            // The padding depends on the actual size of the returned image, therefore provide a function
+            getPadding: function (pixmapWidth, pixmapHeight) {
+                // Find out if the mask extends beyond the visible pixels
+                var paddingWanted;
+                ["top", "left", "right", "bottom"].forEach(function (key) {
+                    if (paddedInputBounds[key] !== visibleInputBounds[key]) {
+                        paddingWanted = true;
+                        return false;
+                    }
+                });
+
+                // When Photoshop produces inaccurate results, the padding is adjusted to compensate
+                // When no padding is requested, this may be unwanted, so return a padding of 0px
+                if (!paddingWanted) {
+                    return { left: 0, top: 0, right: 0, bottom: 0 };
                 }
+
+                var // How much padding is necessary in both dimensions
+                    missingWidth  = paddedOutputWidth  - pixmapWidth,
+                    missingHeight = paddedOutputHeight - pixmapHeight,
+                    // How of the original padding was on which side (default 0 to counteract NaN)
+                    leftRatio     = ((visibleInputBounds.left - paddedInputBounds.left) / paddingInputWidth)  || 0,
+                    topRatio      = ((visibleInputBounds.top  - paddedInputBounds.top)  / paddingInputHeight) || 0,
+                    // Concrete padding size on one side so the other side can use the rest
+                    leftPadding   = Math.round(leftRatio * missingWidth),
+                    topPadding    = Math.round(topRatio  * missingHeight);
+
+                // Padding: how many transparent pixels to add on which side
+                return {
+                    left:   leftPadding,
+                    top:    topPadding,
+                    right:  missingWidth  - leftPadding,
+                    bottom: missingHeight - topPadding
+                };
             }
-            else {
-                expectedWidth  = outerWidth;
-                expectedHeight = outerHeight;
-            }
-
-            if (inputRect)  { params.inputRect  = inputRect;  }
-            if (outputRect) { params.outputRect = outputRect; }
-        }
-
-        params.expectedWidth  = expectedWidth;
-        params.expectedHeight = expectedHeight;
-
-        return params;
+        };
     };
 
     /**


### PR DESCRIPTION
And make it easy for them to request the pixmap accordingly

Test files can be found in the [Bounds-Test repository](https://github.com/adobe-photoshop/generator-bounds-test) (not public).
