### PR TITLE
Use a better dithering method

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -69,7 +69,10 @@
                 " -flatten -clone 0 -channel A -threshold 99% -compose dst-in -composite ) -delete 0").split(/ /));
         }
         if (format === "png" && String(quality) === "8") {
-            // Just make sure to use a palette
+            // The default Riemersma dithering is broken in ImageMagick 6.8.6-2
+            // Use Floyd Steinberg instead - it looks better, too
+            args.push("-dither", "FloydSteinberg");
+            // Make sure to use a palette
             args.push("-colors", 256);
         }
         if (format === "jpg" || format === "webp") {


### PR DESCRIPTION
Fixes a bug that Tom Attic discovered where exporting to PNG8 after scaling could result in bad results like this:

![Original](http://i.imgur.com/EPUfXBl.png)  ->  ![Scaled](http://i.imgur.com/IQdoHQv.png)
