### PR TITLE
When using an explicit PNG quality, make sure the output is actually using that.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -75,6 +75,12 @@
             // Make sure to use a palette
             args.push("-colors", 256);
         }
+        else if (format === "png" && String(quality) === "24") {
+            args.push("-define", "PNG:color-type=" + 2);
+        }
+        else if (format === "png" && String(quality) === "32") {
+            args.push("-define", "PNG:color-type=" + 6);
+        }
         if (format === "jpg" || format === "webp") {
             quality = quality || DEFAULT_IMAGE_QUALITY;
             args.push("-quality", quality);


### PR DESCRIPTION
However, if no quality is set, leave it up to ImageMagick to decide on the format.

Fixes Watson bug 3636776.
