### PR TITLE
When using an explicit PNG quality, make sure the output is actually using that.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -51,10 +51,10 @@
     function getConvertArgumentsForSettings(settings) {
         var args    = [],
             format  = settings.format,
-            quality = settings.quality;
+            quality = String(settings.quality);
 
         // Now perform color conversions
-        if (format === "jpg" || (format === "png" && String(quality) === "24")) {
+        if (format === "jpg" || (format === "png" && quality === "24")) {
             // Blend against a white background. Otherwise, semi-transparent pixels would just
             // lose their transparency, making the colors too intense
             args.push("-background", BACKGROUND_COLOR_FOR_FLATTENING, "-flatten");
@@ -68,12 +68,22 @@
             args = args.concat(("( -clone 0 ) -delete 0 ( -clone 0 -background " + BACKGROUND_COLOR_FOR_FLATTENING +
                 " -flatten -clone 0 -channel A -threshold 99% -compose dst-in -composite ) -delete 0").split(/ /));
         }
-        if (format === "png" && String(quality) === "8") {
-            // The default Riemersma dithering is broken in ImageMagick 6.8.6-2
-            // Use Floyd Steinberg instead - it looks better, too
-            args.push("-dither", "FloydSteinberg");
-            // Make sure to use a palette
-            args.push("-colors", 256);
+        if (format === "png") {
+            if (quality === "8") {
+                // The default Riemersma dithering is broken in ImageMagick 6.8.6-2
+                // Use Floyd Steinberg instead - it looks better, too
+                args.push("-dither", "FloydSteinberg");
+                // Do not force type 3 as that seems to remove the alpha channel
+                // Just reduce the number of colors, inspiring ImageMagick to use a palette anyway (with RGBA colors)
+                args.push("-colors", 256);
+            }
+            else if (quality === "24") {
+                args.push("-define", "PNG:color-type=" + 2);
+            }
+            // This only forces RGBA colors when quality 32 is set explicitly. Otherwise, ImageMagick gets to decide.
+            else if (quality === "32") {
+                args.push("-define", "PNG:color-type=" + 6);
+            }
         }
         if (format === "jpg" || format === "webp") {
             quality = quality || DEFAULT_IMAGE_QUALITY;


### PR DESCRIPTION
However, if no quality is set, leave it up to ImageMagick to decide on the format.

Fixes Watson bug 3636776
