### PR TITLE
Improved error logging for incompatible plugin versions.

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,6 +135,7 @@
                         generator.loadPlugin(absolutePluginPath);
                         pluginsLoaded++;
                     } catch (e2) {
+                        console.error(e2);
                         if (!firstException) {
                             firstException = e2;
                         }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -830,8 +830,7 @@
         } else if (packageConfig.version &&
             !semver.satisfies(packageConfig.version, metadata["generator-core-version"])) {
             handleIncompatiblePlugin(metadata);
-            throw new Error("Attempted to load a plugin '%s' that is incompatible with this version of " +
-                " generator-core. generator-core version: %s, plugin compatibility: %s",
+            throw new Error("The plugin "+metadata["name"]+" is incompatible with this version of generator-core. generator-core version: "+packageConfig.version+", plugin compatibility: "+metadata["generator-core-version"],
                 metadata.name, packageConfig.version, metadata["generator-core-version"]);
         }
 


### PR DESCRIPTION
Version incompatibility errors were being suppressed by the logic around only logging the error in `firstException`. If you're loading a plugins folder, the error thrown when trying to load that folder _as a plugin_ will always be the `firstException`, so you miss any subsequent errors.

Also, the %s tokens were not being swapped out in `generator.js`, so made the line use plain ol' string concatenation.
