### PR TITLE
Move base64 encode of embedded images to Node.js

### DIFF
--- a/lib/jsx/getLayerSVG.jsx
+++ b/lib/jsx/getLayerSVG.jsx
@@ -98,31 +98,8 @@ svg.documentColorMode = function ()
 	return s;
 };
 
-// Encode data as Base64.
-svg.encodeBase64 = function (src)
-{
-    var base64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-    var i, c0, c1, c2, e0, e1, e2, e3, dst = "";
- 
-    for (i = 0; i < src.length;)
-    {
-        c0 = src.charCodeAt(i++);
-        c1 = src.charCodeAt(i++);
-        c2 = src.charCodeAt(i++);
-
-        e0 = c0 >> 2;
-        e1 = ((c0 & 3) << 4) | (c1 >> 4);
-        e2 = (i - 2 >= src.length) ? 64 : (((c1 & 15) << 2) | (c2 >> 6));
-        e3 = (i - 1 >= src.length) ? 64 : (c2 & 63);
-
-        dst = dst + base64chars[e0] + base64chars[e1]
-                  + base64chars[e2] + base64chars[e3];
-    }
-
-    return dst;
-};
-
 // Call internal PS code to write the current layer's pixels and convert it to PNG.
+// Note this takes care of encoding it into base64 format (ES is too slow at this).
 svg.writeLayerPNGfile = function (path)
 {
     var desc = new ActionDescriptor();
@@ -878,11 +855,11 @@ svg.getImageLayerSVGdata = function ()
 {
     var pngPath = new File(Folder.temp + "/png4svg" + this.currentLayer.layerID).fsName;
     this.writeLayerPNGfile(pngPath);
-
-    var pngFile = new File(pngPath + ".png");
+    var pngFile = new File(pngPath + ".base64");
     pngFile.open('r');
-    pngFile.encoding = "BINARY";
-    var pngData64 = this.encodeBase64(pngFile.read());
+    pngFile.encoding = "UTF-8";
+
+    var pngData64 = pngFile.read();
     pngFile.close();
     pngFile.remove();
     this.addParam('xlink:href', "data:img/png;base64," + pngData64);

--- a/lib/png2base64.js
+++ b/lib/png2base64.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*
+ * Convert a PNG file to Base64 encoding.  Used to embed PNG files into SVG files.
+ */
+
+(function () {
+    "use strict";
+    
+    var fs = require("fs");
+
+    if (process.argv.length !== 3) {
+        console.error(process.argv[1] + ": Filename missing\n");
+        process.exit(1);
+    }
+    
+    var pngFilename = process.argv[2];
+    if (! fs.existsSync(pngFilename)) {
+        console.error(process.argv[1] + ": Path missing: " + pngFilename + "\n");
+        process.exit(1);
+    }
+    
+    var pngData = fs.readFileSync(pngFilename);
+    var b64Filename = pngFilename.replace(/[.]png$/, ".base64");
+    fs.writeFileSync(b64Filename, pngData.toString("base64"));
+}());


### PR DESCRIPTION
Trying to encode Base64 in ExtendScript was catastrophically slow for
large PNGs.  A 2.7MB file takes about 20 minutes.  Moved encoding to a
utility written in Node.JS where it's done in a fraction of a second
(uses an internal built-in).
