### PR TITLE
Change plugin loading logic to allow plugin overriding

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -798,11 +798,58 @@
     Generator.prototype.isConnected = function () {
         return (this._photoshop && this._photoshop.isConnected());
     };
-    
-    Generator.prototype.loadPlugin = function (directory) {
+
+    Generator.prototype.getPluginMetadata = function (directory) {
         var fs = require("fs"),
             resolve = require("path").resolve,
-            metadata = null,
+            metadata = null;
+
+        // Make sure a directory was specified
+        if (!fs.statSync(directory).isDirectory()) {
+            throw new Error("Argument error: specified path is not a directory");
+        }
+
+        // Load metadata
+        try {
+            metadata = require(resolve(directory, "package.json"));
+        } catch (metadataError) {
+            throw new Error("Error reading metadata for plugin at path '" + directory + "': " + metadataError.message);
+        }
+
+        // Ensure plugin has a name
+        if (!(metadata && metadata.name && typeof metadata.name === "string")) {
+            throw new Error("Invalid metadata for plugin at path '" + directory +
+                "' (plugins must have a valid package.json file with 'name' property): " +
+                JSON.stringify(metadata));
+        }
+
+        return metadata;
+    };
+
+    Generator.prototype.checkPluginCompatibility = function (metadata) {
+        var result = {compatible: true, message: null};
+
+        if (!metadata["generator-core-version"]) {
+            // Still compatible, but has a warning.
+            result.compatible = true;
+            result.message = "Warning: Plugin '" + metadata.name +
+                "' did not specify which versions of generator-core it is compatible with." +
+                " It will be loaded anyway, but providing generator-core-version" +
+                " in its package.json is recommended.";
+        } else if (packageConfig.version &&
+            !semver.satisfies(packageConfig.version, metadata["generator-core-version"])) {
+            result.compatible = false;
+            result.message = "The plugin " + metadata.name + " is incompatible with this version of generator-core." +
+                " generator-core version: " + packageConfig.version +
+                ", plugin compatibility: " + metadata["generator-core-version"];
+        }
+
+        return result;
+    };
+
+    Generator.prototype.loadPlugin = function (directory) {
+        var metadata = null,
+            compatibility = null,
             self = this;
 
         function handleIncompatiblePlugin(metadata) {
@@ -811,35 +858,27 @@
             // alert if we've never alerted for it before.
         }
         
-        // Make sure a directory was specified
-        if (!fs.statSync(directory).isDirectory()) {
-            throw new Error("Argument error: specified path is not a directory");
-        }
-
-        // Check for metadata and name uniqueness
+        // Get the metadata
         try {
-            metadata = require(resolve(directory, "package.json"));
+            metadata = self.getPluginMetadata(directory);
         } catch (metadataError) {
-            throw new Error("Error reading metadata for plugin at path '" + directory + "': " + metadataError.message);
+            throw new Error("Could not load plugin: " + metadataError.message);
         }
 
-        if (!(metadata && metadata.name && typeof metadata.name === "string")) {
-            throw new Error("Invalid metadata for plugin at path '" + directory +
-                "' (plugins must have a valid package.json file with 'name' property): " +
-                JSON.stringify(metadata));
-        } else if (self._plugins[PLUGIN_KEY_PREFIX + metadata.name]) {
+        // Check if it is compatible
+        compatibility = self.checkPluginCompatibility(metadata);
+        if (!compatibility.compatible) {
+            handleIncompatiblePlugin(metadata);
+            console.error(compatibility.message);
+            throw new Error(compatibility.message);
+        } else if (compatibility.message) {
+            console.warn(compatibility.message);
+        }
+
+        // Check for uniqueness
+        if (self._plugins[PLUGIN_KEY_PREFIX + metadata.name]) {
             throw new Error("Attempted to load a plugin with a name that is already used. Path: '" +
                 directory + "', name: '" + metadata.name + "'");
-        } else if (!metadata["generator-core-version"]) {
-            console.warn("Warning: Plugin '%s' did not specify which versions of generator-core" +
-                " it is compatible with. It will be loaded anyway, but providing generator-core-version" +
-                " in its package.json is recommended.", metadata.name);
-        } else if (packageConfig.version &&
-            !semver.satisfies(packageConfig.version, metadata["generator-core-version"])) {
-            handleIncompatiblePlugin(metadata);
-            throw new Error("The plugin " + metadata.name + " is incompatible with this version of generator-core." +
-                " generator-core version: " + packageConfig.version +
-                ", plugin compatibility: " + metadata["generator-core-version"]);
         }
 
         // Do the actual plugin load

--- a/test/plugins/multi-plugin-test/a/notaplugin/dummy.txt
+++ b/test/plugins/multi-plugin-test/a/notaplugin/dummy.txt
@@ -1,0 +1,1 @@
+dummy folder

--- a/test/plugins/multi-plugin-test/a/one/main.js
+++ b/test/plugins/multi-plugin-test/a/one/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/a/one/package.json
+++ b/test/plugins/multi-plugin-test/a/one/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version-disabled": "0.0.1",
+  "generator-core-version": "~2",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/plugins/multi-plugin-test/a/three/main.js
+++ b/test/plugins/multi-plugin-test/a/three/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/a/three/package.json
+++ b/test/plugins/multi-plugin-test/a/three/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version": "0.0.3",
+  "generator-core-version-disabled": "~1",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/plugins/multi-plugin-test/a/two/main.js
+++ b/test/plugins/multi-plugin-test/a/two/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/a/two/package.json
+++ b/test/plugins/multi-plugin-test/a/two/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version": "0.0.2",
+  "generator-core-version": "~2",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/plugins/multi-plugin-test/b/five/main.js
+++ b/test/plugins/multi-plugin-test/b/five/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/b/five/package.json
+++ b/test/plugins/multi-plugin-test/b/five/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version": "0.2.0",
+  "generator-core-version": "~2",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/plugins/multi-plugin-test/b/four/main.js
+++ b/test/plugins/multi-plugin-test/b/four/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/b/four/package.json
+++ b/test/plugins/multi-plugin-test/b/four/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version": "0.1.0",
+  "generator-core-version": "~2",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/plugins/multi-plugin-test/b/six/main.js
+++ b/test/plugins/multi-plugin-test/b/six/main.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+(function () {
+    "use strict";
+
+    var config = require("./package.json");
+
+    var MENU_ID = "multi-plugin-test",
+        MENU_STRING = "Loaded v" + config.version + " from " + __dirname;
+
+
+    function init(generator) {
+        generator.addMenuItem(MENU_ID, MENU_STRING, true, false).then(
+            function () {
+                console.log("Created multi-plugin test menu.");
+            }, function () {
+                console.error("Failed to create multi-plugin test menu. This should not happen.");
+            }
+        );
+    }
+
+    exports.init = init;
+
+}());

--- a/test/plugins/multi-plugin-test/b/six/package.json
+++ b/test/plugins/multi-plugin-test/b/six/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generator-multi-plugin-test",
+  "version": "0.3.0",
+  "generator-core-version": "~1",
+  "description": "generator plugin to test loading correct version if multiple versions exist",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
Now, the plugin logic works like this:
1. Scan all specified plugin paths for any plugins
2. Group plugins by their name, and sort by descending version number
3. For each plugin name, go down the list of plugins until one is successfully loaded

Also handles things like plugins that are incompatible with current core version (it won't load these), and plugins without versions (it will give these lowest precedent, but will load them.)

Addresses #103 and watson bug 3678268
