### PR TITLE
pngquant

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -33,6 +33,7 @@
 
     // Constants
     var DEFAULT_IMAGE_QUALITY           = 90,
+        PNGQUANT_ENABLED                = true,
         BACKGROUND_COLOR_FOR_FLATTENING = "#fff";
 
     // Helper functions
@@ -45,6 +46,18 @@
             execpath = resolve(psPath, "convert");
         }
         
+        return spawn(execpath, convertArgs);
+    }
+
+    function runPngquant(psPath, convertArgs) {
+        var execpath = null;
+
+        if (process.platform === "darwin") {
+            execpath = resolve(psPath, "./Adobe Photoshop CC.app/Contents/MacOS/pngquant");
+        } else {
+            execpath = resolve(psPath, "pngquant");
+        }
+
         return spawn(execpath, convertArgs);
     }
 
@@ -69,6 +82,12 @@
                 " -flatten -clone 0 -channel A -threshold 99% -compose dst-in -composite ) -delete 0").split(/ /));
         }
         if (format === "png") {
+            if (PNGQUANT_ENABLED && quality === "8") {
+                // Use ImageMagick to create 32-bit PNG with appropriate padding, etc.
+                // and then pngquant will convert it to PNG8.
+                quality = 32;
+            }
+
             if (quality === "8") {
                 // The default Riemersma dithering is broken in ImageMagick 6.8.6-2
                 // Use Floyd Steinberg instead - it looks better, too
@@ -180,14 +199,28 @@
             stderr += chunk;
         });
 
-        // Pipe convert's output (the produced image) into the file stream
-        imProc.stdout.pipe(fileStream);
+        // pngquant changes the process from `convert < pixmap > fileStream`
+        // to `convert < pixmap | pngquant > fileStream`
+        if (PNGQUANT_ENABLED && settings.format === "png" && settings.quality === "8") {
+            var pngquantProc = runPngquant(psPath, ["-"]);
+
+            pngquantProc.on("error", function (err) { onStreamError("Error with pngquant: " + err); });
+            pngquantProc.stdin.on("error",  function (err) { onStreamError("Error with pngquant's STDIN: "  + err); });
+            pngquantProc.stdout.on("error", function (err) { onStreamError("Error with pngquant's STDOUT: " + err); });
+            pngquantProc.stderr.on("error", function (err) { onStreamError("Error with pngquant's STDERR: " + err); });
+
+            pngquantProc.stdout.pipe(fileStream);
+            imProc.stdout.pipe(pngquantProc.stdin);
+        } else {
+            // Pipe convert's output (the produced image) into the file stream
+            imProc.stdout.pipe(fileStream);
+        }
 
         // Send the pixmap to convert
         imProc.stdin.end(pixmap.pixels);
 
-        // Wait until convert is done
-        imProc.stdout.on("close", function () {
+        // Wait until convert is done (pipe from the last utility will close the stream)
+        fileStream.on("close", function () {
             if (stderr) {
                 fileCompleteDeferred.reject("ImageMagick error: " + stderr);
             } else {


### PR DESCRIPTION
To run it on OS X you'll need `pngquant` executable in `Adobe Photoshop CC.app/Contents/MacOS/`. I recommend multicore build from [pngquant.org](http://pngquant.org/):

```
 curl http://pngquant.org/pngquant.tar.bz2 | tar xz pngquant-openmp
 mv ./pngquant-openmp '/Applications/Adobe Photoshop CC/Adobe Photoshop CC.app/Contents/MacOS/pngquant'
```

[Windows binary is here](http://css-ig.net/tools/zip/pngquantv2-2.0.1.zip).

This pull request changes how 8-bit PNG images are generated. Instead of generating palette with ImageMagick, [which has buggy transparency](http://www.imagemagick.org/discourse-server/viewtopic.php?t=23340) it uses ImageMagick to generate 32-bit PNG (to support padding and background features) and then converts image to PNG8 **with alpha** :sparkles: using `pngquant`.

Integration is done via streams, so no extra files are created.
