### PR TITLE
Add getPhotoshopExecutableLocation API

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -40,9 +40,9 @@
         var execpath = null;
         
         if (process.platform === "darwin") {
-            execpath = resolve(psPath, "./Adobe Photoshop CC.app/Contents/MacOS/convert");
-        } else {
             execpath = resolve(psPath, "convert");
+        } else {
+            execpath = resolve(psPath, "convert.exe");
         }
         
         return spawn(execpath, convertArgs);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -132,12 +132,12 @@
         
         return (connectToPhotoshop().then(
             function () {
-                self.getPhotoshopPath().then(
+                self.getPhotoshopExecutableLocation().then(
                     function (p) { // success
                         self._photoshop._applicationPath = p;
                     },
                     function (err) { // error
-                        console.error("Error retrieving Photoshop path", err);
+                        console.error("Error retrieving Photoshop executable location", err);
                     }
                 );
             })
@@ -253,8 +253,42 @@
         this.evaluateJSXFile("./jsx/alert.jsx", { message: message, replacements: stringReplacements });
     };
 
+    /**
+     * Returns a Promise that resolves to the full path to the location of the root 
+     * Photoshop install directory (where things like the third-party "Plug-ins"
+     * directory live).
+     * 
+     * On Mac this will look something like:
+     *    /Applications/Adobe Photoshop CC
+     *
+     * On Windows this will look something like:
+     *    C:\Program Files\Adobe\Adobe Photoshop CC (64 Bit)
+     *
+     * See also: Generator.prototype.getPhotoshopExecutableLocation
+     */
     Generator.prototype.getPhotoshopPath = function () {
         return this.evaluateJSXString("File(app.path).fsName");
+    };
+
+    /**
+     * Returns a Promise that resolves to the full path to the location of the Photoshop
+     * executable (not including the name of the executable itself.) On Mac, this gives
+     * a location *inside* the .app bundle.
+     *
+     * Important: Due to a bug in Photoshop (that likely won't be fixed), this function
+     * will not work properly if there is a literal "%20" in the absolute path. Moreover,
+     * PS as a whole may not work properly if there is a literal "%20" in its executable path
+     * 
+     * On Mac this will look something like:
+     *    /Applications/Adobe Photoshop CC/Adobe Photoshop CC.app/Contents/MacOS
+     *
+     * On Windows this will look something like:
+     *    C:\Program Files\Adobe\Adobe Photoshop CC (64 Bit)
+     *
+     * See also: Generator.prototype.getPhotoshopPath
+     */
+    Generator.prototype.getPhotoshopExecutableLocation = function () {
+        return this.evaluateJSXFile("./jsx/getPhotoshopExecutableLocation.jsx", {});
     };
 
     Generator.prototype.getPhotoshopLocale = function () {

--- a/lib/jsx/getPhotoshopExecutableLocation.jsx
+++ b/lib/jsx/getPhotoshopExecutableLocation.jsx
@@ -1,0 +1,17 @@
+/*global charIDToTypeID, stringIDToTypeID, ActionReference, executeAction, ActionDescriptor, DialogModes, File */
+
+var classProperty = charIDToTypeID("Prpr");
+var classApplication = charIDToTypeID("capp");
+var typeOrdinal = charIDToTypeID("Ordn");
+var enumTarget = charIDToTypeID("Trgt");
+var kexecutablePathStr = stringIDToTypeID("executablePath");
+var typeNULL = charIDToTypeID("null");
+var actionGet = charIDToTypeID("getd");
+
+var desc1 = new ActionDescriptor();
+var ref1 = new ActionReference();
+ref1.putProperty(classProperty, kexecutablePathStr);
+ref1.putEnumerated(classApplication, typeOrdinal, enumTarget);
+desc1.putReference(typeNULL, ref1);
+var result = executeAction(actionGet, desc1, DialogModes.NO);
+String((new File(result.getPath(kexecutablePathStr))).fsName);


### PR DESCRIPTION
Fixes #101 and Watson 3617656.

When testing with a recent Jenkins build on mac, it is IMPERATIVE that you delete the .app bundle that does NOT end in "2014".
