### PR TITLE
Fix bug where savePixmap settings.quality was incorrectly compared to a string

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -136,7 +136,7 @@
         // Define the output
         var format = settings.format;
         // "png8" as the ImageMagick format produces GIF-like PNGs (binary transparency)
-        if (format === "png" && settings.quality && settings.quality !== "8") {
+        if (format === "png" && settings.quality && settings.quality !== 8) {
             format = format + settings.quality;
         }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -934,12 +934,23 @@
      * @param settings   An object with settings for converting the image
      * @param {!String}  settings.format       ImageMagick output format
      * @param {?integer} settings.quality      A number indicating the quality - the meaning depends on the format
-     * @param {?integer} settings.ppi          The image's pixel density
+     * @param {?number}  settings.ppi          The image's pixel density
      */
     Generator.prototype.savePixmap = function (pixmap, path, settings) {
         var self    = this,
             psPath  = self._photoshop._applicationPath,
             convert = require("./convert");
+
+        // check that arguments are of the correct type
+        pixmap.width          = parseInt(pixmap.width, 10);
+        pixmap.height         = parseInt(pixmap.height, 10);
+        pixmap.bitsPerChannel = parseInt(pixmap.bitsPerChannel, 10);
+        if (settings.hasOwnProperty("quality")) {
+            settings.quality  = parseInt(settings.quality, 10);
+        }
+        if (settings.hasOwnProperty("ppi")) {
+            settings.ppi      = parseFloat(settings.ppi);
+        }
 
         return convert.savePixmap(psPath, pixmap, path, settings);
     };


### PR DESCRIPTION
Also ensures that arguments to savePixmap are coerced to the correct types.
