### PR TITLE
Fix getOpenDocumentIDs with one open document

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -377,7 +377,9 @@
      */
     Generator.prototype.getOpenDocumentIDs = function () {
         return this.evaluateJSXFile("./jsx/getOpenDocumentIDs.jsx", {}).then(function (ids) {
-                if (ids.length > 0) {
+                if (typeof ids === "number") {
+                    return [ids];
+                } else if (typeof ids === "string" && ids.length > 0) {
                     return ids.split(":").map(function (id) { return parseInt(id, 10); });
                 } else {
                     return [];


### PR DESCRIPTION
In which a single open document is reported as no open documents because `"1"` from ExtendScript is turned into `1` in Node.

CC @joelrbrandt 
