### PR TITLE
Ensure that effects are scaled for pixmaps that are scaled by a fractional amount

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -858,15 +858,20 @@
             paddingInputHeight  = paddedInputHeight - visibleInputHeight,
 
             // Designated image size
-            paddedOutputWidth   = Math.ceil(targetWidth  || (paddedInputWidth *
-                                    (targetHeight ? (targetHeight / paddedInputHeight) : targetScaleX))),
-            paddedOutputHeight  = Math.ceil(targetHeight || (paddedInputHeight *
-                                    (targetWidth  ? (targetWidth  / paddedInputWidth)  : targetScaleY))),
+            paddedOutputWidthFloat = targetWidth  || (paddedInputWidth *
+                                    (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleX)),
+            paddedOutputHeightFloat = targetHeight || (paddedInputHeight *
+                                    (targetHeight  ? (targetHeight  / paddedInputHeight)  : targetScaleY)),
+
+            // Effects are not scaled when the transformation is non-uniform
+            effectsScaled       =
+                (paddedOutputWidthFloat / paddedInputWidth) === (paddedOutputHeightFloat / paddedInputHeight),
+
+            paddedOutputWidth   = Math.ceil(paddedOutputWidthFloat),
+            paddedOutputHeight  = Math.ceil(paddedOutputHeightFloat),
+
             paddedOutputScaleX  = paddedOutputWidth  / paddedInputWidth,
             paddedOutputScaleY  = paddedOutputHeight / paddedInputHeight,
-            
-            // Effects are not scaled when the transformation is non-uniform
-            effectsScaled       = paddedOutputScaleX === paddedOutputScaleY,
 
             // How much to scale everything that can be scaled (static + padding, maybe effects)
             scaleX              = effectsScaled ? paddedOutputScaleX : paddedOutputScaleX +


### PR DESCRIPTION
This fixes two bugs in `Generator.prototype.getPixmapParams`:
1. The expressions that were used to define `paddedOutputHeight` and `paddedOutputHeight` mixed up width and height; and
2. The test for scaling uniformity, which determines whether or not effects are scaled, occurred after a ceiling computation, which in some cases caused effects scaled by a non-integral factor to be considered non-uniform. 

Addresses adobe-photoshop/generator-assets#200. I've also added a new regression test to verify this in  adobe-photoshop/generator-assets-automation@89241e359cdda7217f736d660f6f82f48d258ed6. 

CC @joelrbrandt 
