### PR TITLE
[Headlights] Log startup and plugin loading messages distinctly from version messages

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -145,7 +145,7 @@
         return (connectToPhotoshop().then(
             function () {
                 // Setup Headlights logging
-                self._logHeadlights("Auto startup: " + packageConfig.name);
+                self._logHeadlights("Startup");
                 self._logHeadlights("Version: " + packageConfig.version);
                 self.onPhotoshopEvent("generatorMenuChanged", function (event) {
                     var menu = event.generatorMenuChanged;


### PR DESCRIPTION
```
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Auto startup: generator-core" time="2014-04-16T17:54:32Z" seq="53" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Version: 3.0.0-dev" time="2014-04-16T17:54:32Z" seq="54" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin loaded: generator-assets" time="2014-04-16T17:54:33Z" seq="64" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin version: generator-assets:2.0.0-dev" time="2014-04-16T17:54:33Z" seq="65" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin loaded: generator-assets-automation" time="2014-04-16T17:54:33Z" seq="84" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin version: generator-assets-automation:0.0.1" time="2014-04-16T17:54:33Z" seq="85" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin loaded: generator-weblogger" time="2014-04-16T17:54:33Z" seq="86" />
<EventRec doc="0" category="Scripting" subcategory="Generator" name="Generator: Plugin version: generator-weblogger:0.0.1" time="2014-04-16T17:54:33Z" seq="87" />
```

CC @joelrbrandt 
