### PR TITLE
Add interpolationType parameter Generator.prototype.getPixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -612,6 +612,48 @@
         return this.emit.apply(this, args);
     };
 
+    /**
+     * Interpolation types.
+     * 
+     * @const
+     * @see Generator.prototype.getPixmap
+     * @type {string}
+     */
+    Object.defineProperties(Generator.prototype, {
+        "INTERPOLATION_NEAREST_NEIGHBOR": {
+            value: "nearestNeighbor",
+            enumerable: true
+        },
+        "INTERPOLATION_BILINEAR": {
+            value: "bilinear",
+            enumerable: true
+        },
+        "INTERPOLATION_BICUBIC": {
+            value: "bicubic",
+            enumerable: true
+        },
+        "INTERPOLATION_BICUBIC_SMOOTHER": {
+            value: "bicubicSmoother",
+            enumerable: true
+        },
+        "INTERPOLATION_BICUBIC_SHARPER": {
+            value: "bicubicSharper",
+            enumerable: true
+        },
+        "INTERPOLATION_BICUBIC_AUTOMATIC": {
+            value: "bicubicAutomatic",
+            enumerable: true
+        },
+        "INTERPOLATION_PRESERVE_DETAILS_UPSCALE": {
+            value: "preserveDetailsUpscale",
+            enumerable: true
+        },
+        "INTERPOLATION_AUTOMATIC": {
+            value: "automaticInterpolation",
+            enumerable: true
+        },
+    });
+
     // TODO - JRB - 2/9/14
     // KVLR has a sendLayerShapeToClient action that is similar to sendLayerThumbnailToNetworkClient
     // We should create a getVector function that is similar to getPixmap
@@ -652,6 +694,10 @@
      *     whether to (if true) defer to the user's color settings in PS, or (if false) to force dither in any
      *     case where a conversion to 8-bit RGB would otherwise be lossy. If allowDither is false, then the
      *     value of this parameter is ignored. (Default: false)
+     * @param {string=} settings.interpolationType Force pixmap scaling to use the given interpolation method.
+     *     If defined, the value should be one of the Generator.prototype.INTERPOLATION constants. Otherwise,
+     *     Photoshop's default interpolation type (as specified in Preferences > Image Interpolation) is used.
+     *     (Default: undefined)
      */
     Generator.prototype.getPixmap = function (documentId, layerId, settings) {
         if (arguments.length !== 3) {
@@ -675,7 +721,8 @@
                 useSmartScaling: settings.useSmartScaling || false,
                 includeAncestorMasks: settings.includeAncestorMasks || false,
                 allowDither: settings.allowDither || false,
-                useColorSettingsDither: settings.useColorSettingsDither || false
+                useColorSettingsDither: settings.useColorSettingsDither || false,
+                interpolationType: settings.interpolationType
             };
 
         // Because of PS communication irregularities in different versions of PS, it's very complicated to

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -71,6 +71,16 @@ if (params.inputRect && params.outputRect) {
     // Absolute scaling may not keep the aspect ratio intact, in which case effects
     // cannot be scaled. To be consistent, turn it off for all of absolute scaling
     // transform.putBoolean(stringIDToTypeID("scaleStyles"), false);
+
+    if (params.interpolationType) {
+        transform.putEnumerated(stringIDToTypeID("interpolation"),
+                                stringIDToTypeID("interpolationType"),
+                                stringIDToTypeID(params.interpolationType));
+
+        actionDescriptor.putEnumerated(stringIDToTypeID("interpolation"),
+                                stringIDToTypeID("interpolationType"),
+                                stringIDToTypeID(params.interpolationType));
+    }
 }
 else if (params.scaleX && params.scaleY && (params.scaleX !== 1 || params.scaleY !== 1)) {
     transform = new ActionDescriptor();
@@ -81,9 +91,16 @@ else if (params.scaleX && params.scaleY && (params.scaleX !== 1 || params.scaleY
 
     transform.putDouble(stringIDToTypeID("width"), params.scaleX * 100);
     transform.putDouble(stringIDToTypeID("height"), params.scaleY * 100);
-    transform.putEnumerated(stringIDToTypeID("interpolation"),
-                            stringIDToTypeID("interpolationType"),
-                            stringIDToTypeID("automaticInterpolation"));
+
+    if (params.interpolationType) {
+        transform.putEnumerated(stringIDToTypeID("interpolation"),
+                                stringIDToTypeID("interpolationType"),
+                                stringIDToTypeID(params.interpolationType));
+
+        actionDescriptor.putEnumerated(stringIDToTypeID("interpolation"),
+                                stringIDToTypeID("interpolationType"),
+                                stringIDToTypeID(params.interpolationType));
+    }
 }
 
 if (transform) {


### PR DESCRIPTION
This pull request adds an optional property to the settings parameter of `Generator.prototype.getPixmap` to control the interpolation method used for scaling pixmaps. The value of this property can either be one of the newly defined `Generator.prototype.INTERPOLATION` constants, or undefined. If undefined, the interpolation method is left up to Photoshop, which can be observed and changed in `Preferences > Image Interpolation`. The default for this setting seems to be `Bicubic Automatic`.

To test this, I suggest the following:
1. Make sure Image Interpolation has the default `Bicubic Automatic` setting and confirm that all tests pass with the Assets Automation plugin.
2. Download and open this [test PSD](http://cloud.wehrman.org/3s2e0b1Q3V3y).
3. Fire up Generator and observe the output PNG's smooth edges.
4. Disabled Generator, change the default interpolation method in `Preferences > Image Interpolation` to `Nearest Neighbor` and re-enable Generator. Observe the output PNG's jaggy edges.
5. Open up [`lib/dom/renderer.js`](https://github.com/adobe-photoshop/generator-assets/blob/iwehrman/v2/lib/renderer.js#L323) and add an `interpolationType` property to the settings parameter in the call to `getPixmap`. (The link above takes you to the right place to do this.) Try setting it to `this._generator.INTERPOLATION_BICUBIC_AUTOMATIC`. Re-run generator and observe the return of the output PNG's smooth edges.
6. Try setting `interpolationType` to the other `Generator.prototype.INTERPOLATION` constants and observe the changes in the output PNG.

Note: I thought about defining these constants directly on the Generator constructor, but decided against it because it isn't common for client code to require the Generator module directly. 

Thanks to @timothynoel for the hint about both on the thumbnail and the transform having interpolation types. 

Over to @joelrbrandt for review. If you merge this, don't forget to update the [API changes wiki page](https://github.com/adobe-photoshop/generator-core/wiki/API-Changes) accordingly.

Addresses #202.
