### PR TITLE
Use JSON.stringify instead of require()

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,8 @@
 (function () {
     "use strict";
     
-    var resolve = require("path").resolve,
+    var fs = require("fs"),
+        resolve = require("path").resolve,
         home = process.env[(process.platform === "win32") ? "USERPROFILE" : "HOME"],
         cwd = process.cwd(),
         configLocations = [ // locations are listed from lowest to highest precedence


### PR DESCRIPTION
require() fails when loading config files ending in ".js", because it
tries to interpret the contents as code and fails with a syntax error.
Also a mild security issue to be (possibly) executing code found in a
config file.
