### PR TITLE
extend getPixmap API to allow specifying layer index ranges

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -666,10 +666,10 @@
      * The output rectangle should be of the target size.
      * 
      * @param {!number} documentId Document ID
-     * @param {!number|{firstLayerIndex: number, lastLayerIndex: number, ?hidden: Array.<number>}} layerSpec
+     * @param {!number|{firstLayerIndex: number, lastLayerIndex: number, =§hidden: Array.<number>}} layerSpec
      *     Either the layer ID of the desired layer as a number, or an object of the form {firstLayerIndex: number,
-     *     lastLayerIndex: number, ?hidden: Array.<number>} specifying the desired index range and (optionally) an 
-     *     array of indices to hide. Note that the number form takes a layer ID, *not* a layer index.
+     *     lastLayerIndex: number, ?hidden: Array.<number>} specifying the desired index range, inclusive, and
+     *     (optionally) an array of indices to hide. Note that the number form takes a layer ID, *not* a layer index.
      * @param {!Object}  settings An object with params to request the pixmap
      * @param {?boolean} settings.boundsOnly Whether to return an object with bounds rather than the pixmap. The
      *     returned object will have the format (but with different numbers):

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -4,8 +4,8 @@
 // Required params:
 //   - documentId: The ID of the document requested
 //   - layerSpec: Either the layer ID of the desired layer as a number, or an object of the form
-//         {firstLayerIndex: number, lastLayerIndex: number, ?hidden: Array.<number>} specifying the
-//         desired index range and (optionally) an array of indices to hide.
+//         {firstLayerIndex: number, lastLayerIndex: number, =hidden: Array.<number>} specifying the
+//         desired index range, inclusive, and (optionally) an array of indices to hide.
 //         Note that the number form takes a layer ID, *not* a layer index.
 //   - boundsOnly: Whether to only request the bounds fo the pixmap
 //   Either use absolute scaling by specifying which part of the doc should be transformed into what shape:


### PR DESCRIPTION
The easiest way to test this is to create a document with (for example) three layers and then shim in the line: `layerSpec = {firstLayerIndex: 0, lastLayerIndex: 2};` at the very beginning of the `getPixmap` implementation.

Then, just fire up the generator-assets plugin, tag any ol' layer with an asset tag, and you should get an asset with all the layers.
