### PR TITLE
Fix wildcards 

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -932,9 +932,9 @@
 
             // Designated image size
             paddedOutputWidthFloat = targetWidth  || (paddedInputWidth *
-                                    (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleX)),
+                                    (targetHeight  ? (targetHeight  / paddedInputHeight) : targetScaleX)),
             paddedOutputHeightFloat = targetHeight || (paddedInputHeight *
-                                    (targetHeight  ? (targetHeight  / paddedInputHeight)  : targetScaleY)),
+                                    (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleY)),
 
             // Effects are not scaled when the transformation is non-uniform
             effectsScaled       =


### PR DESCRIPTION
```
$ git blame -L 934,937 lib/generator.js 
fe31546c (Ian Wehrman 2014-04-11 14:53:40 -0700 934)             paddedOutputWidthFloat = targetWidth  || (paddedInputWidth *
fe31546c (Ian Wehrman 2014-04-11 14:53:40 -0700 935)                                     (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleX)),
fe31546c (Ian Wehrman 2014-04-11 14:53:40 -0700 936)             paddedOutputHeightFloat = targetHeight || (paddedInputHeight *
fe31546c (Ian Wehrman 2014-04-11 14:53:40 -0700 937)                                     (targetHeight  ? (targetHeight  / paddedInputHeight)  : targetScaleY)),
```

I completely broke wildcards in fe31546c94f9207e51cb79a70c862d6fbe44a282. This pull request unbreaks them, I think. When computing the size of an output dimension (i.e., width or height) with no target size, then we should scale the input size according to the relative scale of **opposite** dimension when that dimension has a target size. The change I made in that commit doesn't make any sense and was unrelated to the bug I was originally trying to fix. This reverts that dumb change.

Addresses adobe-photoshop/generator-assets#238. Also passes new wildcard tests submitted in adobe-photoshop/generator-assets-automation#5.
