### PR TITLE
add forceSmartPSDPixelScaling to getPixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -706,6 +706,11 @@
      *     If defined, the value should be one of the Generator.prototype.INTERPOLATION constants. Otherwise,
      *     Photoshop's default interpolation type (as specified in Preferences > Image Interpolation) is used.
      *     (Default: undefined)
+     * @param {?boolean} settings.forceSmartPSDPixelScaling: If true, forces PSD Smart objects to be scaled
+     *     completely in pixel space (as opposed to scaling vectors, text, etc. in a smoother fashion.) In
+     *     PS 15.0 and earlier pixel space scaling was the only option. So, setting this to "true" will replicate
+     *     older behavior
+     *     (Default: false))
      */
     Generator.prototype.getPixmap = function (documentId, layerSpec, settings) {
         if (arguments.length !== 3) {
@@ -730,7 +735,8 @@
                 includeAncestorMasks: settings.includeAncestorMasks || false,
                 allowDither: settings.allowDither || false,
                 useColorSettingsDither: settings.useColorSettingsDither || false,
-                interpolationType: settings.interpolationType
+                interpolationType: settings.interpolationType,
+                forceSmartPSDPixelScaling: settings.forceSmartPSDPixelScaling || false
             };
 
         // Because of PS communication irregularities in different versions of PS, it's very complicated to


### PR DESCRIPTION
In PS <= 15.0, PSD smart objects were always scaled in pixel space, which led to fuzzy vectors.

In PS >= 15.1, PSD smart objects will now be scaled in a vector-preserving way. This pull request adds an option to `getPixmap` to force the old behavior.

Also, this opportunistically organizes some of the other transform options in `getLayerPixmap.jsx`
