### PR TITLE
TypeError in getDeepBounds

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -863,15 +863,17 @@
             layer.layers.forEach(function (sub) {
                 var childBounds = this.getDeepBounds(sub);
 
-                if (!bounds) {
-                    bounds = childBounds;
-                } else {
-                    bounds = { // Compute containing rect of union of bounds and childBounds
-                        left:   Math.min(bounds.left,   childBounds.left),
-                        top:    Math.min(bounds.top,    childBounds.top),
-                        right:  Math.max(bounds.right,  childBounds.right),
-                        bottom: Math.max(bounds.bottom, childBounds.bottom)
-                    };
+                if (childBounds) {
+                    if (!bounds) {
+                        bounds = childBounds;
+                    } else {
+                        bounds = { // Compute containing rect of union of bounds and childBounds
+                            left:   Math.min(bounds.left,   childBounds.left),
+                            top:    Math.min(bounds.top,    childBounds.top),
+                            right:  Math.max(bounds.right,  childBounds.right),
+                            bottom: Math.max(bounds.bottom, childBounds.bottom)
+                        };
+                    }
                 }
             }, this);
         }


### PR DESCRIPTION
`Generator.prototype.getDeepBounds` can reasonably return `undefined` in the case of an empty layer group. In certain situations (as demonstrated, e.g., in adobe-photoshop/generator-assets-automation#8), a recursive call that results in `undefined` can cause a `TypeError`. This fixes that error, but continues to allow `getDeepBounds` to return `undefined`.

Addresses adobe-photoshop/generator-assets#244.
