### PR TITLE
Avoid evenodd fill rule for multiple path components

### DIFF
--- a/lib/jsx/getLayerSVG.jsx
+++ b/lib/jsx/getLayerSVG.jsx
@@ -636,7 +636,11 @@ svg.getShapeLayerSVG = function ()
     var gradOverlayID = this.addGradientOverlay();
 
     // For now, Everything Is A Path.  We'll revisit this when shape meta-data is available.
-    this.addText("<path fill-rule=\"evenodd\" ");
+    if (svg.getLayerAttr("layerPathComponentCount") > 1) {
+        this.addText("<path ");
+    } else {
+        this.addText("<path fill-rule=\"evenodd\" ");
+    }
     
     // If there's a gradient overlay effect, the stroke must be added there.
     if (! gradOverlayID) {


### PR DESCRIPTION
Note this requires the latest pluginmanager build.  Fixes adobe-photoshop/generator-assets#241  Note this isn't a complete solution, but should help 80% or so of the common cases (i.e., complex single path shapes & multiple simple paths stacked together should work fine.  Multiple complex (self-intersecting) paths will still have issues.
