### PR TITLE
Reject pending message deferreds on Photoshop error

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -110,10 +110,8 @@
             self._photoshop.on("error", function (err) {
                 _logger.warn("Photoshop error", err);
                 // If the error does refers to a specific command we ran, reject the corresponding deferred
-                if (err.body && err.id) {
-                    if (self._messageDeferreds[err.id]) {
-                        self._messageDeferreds[err.id].reject(err.body);
-                    }
+                if (err && self._messageDeferreds.hasOwnProperty(err.id)) {
+                    self._messageDeferreds[err.id].reject(err.body);
                 }
                 // TODO: Otherwise, gracefully shut down?
             });


### PR DESCRIPTION
If Photoshop replies to a request with an error message that has no body then the deferred for that request is never rejected. This is because the deferred is only rejected if `err.body && err.id` is truthy. But when the message body is empty then `err.body === ""`, and so `err.body && err.id === err.body === ""`. The correct thing to do is, of course, to reject the deferred regardless of whether or not there is a message body. 

And, besides the superfluous and broken test for `err.body`, the `err.id` test is also broken because if `err.id === 0` then the test will also fail incorrectly. The pull request removes both of these broken tests in favor of a single test for whether `err.id` is an own-property of the set of deferreds and, if so, rejects the corresponding deferred.

Partially addresses [3787709](https://watsonexp.corp.adobe.com//#bug=3787709).
