### PR TITLE
add optional pngquant quantization of 8-bit pngs, add option to savePixmap to enable

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -33,7 +33,6 @@
 
     // Constants
     var DEFAULT_IMAGE_QUALITY           = 90,
-        PNGQUANT_ENABLED                = true,
         BACKGROUND_COLOR_FOR_FLATTENING = "#fff";
 
     // Helper functions
@@ -49,16 +48,16 @@
         return spawn(execpath, convertArgs);
     }
 
-    function runPngquant(psPath, convertArgs) {
+    function runPngquant(psPath, pngquantArgs) {
         var execpath = null;
 
         if (process.platform === "darwin") {
-            execpath = resolve(psPath, "./Adobe Photoshop CC.app/Contents/MacOS/pngquant");
-        } else {
             execpath = resolve(psPath, "pngquant");
+        } else {
+            execpath = resolve(psPath, "pngquant.exe");
         }
 
-        return spawn(execpath, convertArgs);
+        return spawn(execpath, pngquantArgs);
     }
 
     function getConvertArgumentsForSettings(settings) {
@@ -85,10 +84,12 @@
             // Avoid embedding time stamps into the file.
             args.push("-define", "png:exclude-chunk=date");
 
-            if (PNGQUANT_ENABLED && quality === "8") {
+            if (settings.usePngquant && quality === "8") {
                 // Use ImageMagick to create 32-bit PNG with appropriate padding, etc.
                 // and then pngquant will convert it to PNG8.
-                quality = 32;
+                quality = "32";
+                settings.quality = 32;
+                settings.pngquantQuality = 8;
             }
 
             if (quality === "8") {
@@ -111,15 +112,6 @@
             quality = quality || DEFAULT_IMAGE_QUALITY;
             args.push("-quality", quality);
         }
-
-        // Define the output
-        // "png8" as the ImageMagick format produces GIF-like PNGs (binary transparency)
-        if (format === "png" && quality && quality !== "8") {
-            format = format + quality;
-        }
-
-        // Write an image of format <format> to STDOUT
-        args.push(format + ":-");
 
         return args;
     }
@@ -181,7 +173,7 @@
         });
 
         // Launch convert
-        var imProc = runConvert(psPath, args);
+        var convertProc = runConvert(psPath, args);
 
         function onStreamError(err) {
             try {
@@ -200,21 +192,21 @@
         }
         
         // Handle errors
-        imProc.on("error", function (err) { onStreamError("Error with convert: " + err); });
-        imProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
-        imProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
-        imProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
+        convertProc.on("error", function (err) { onStreamError("Error with convert: " + err); });
+        convertProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
+        convertProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
+        convertProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
         fileStream.on("error",  function (err) { onStreamError("Error with stream to temporary file: " + err); });
 
         // Capture STDERR
         var stderr = "";
-        imProc.stderr.on("data", function (chunk) {
+        convertProc.stderr.on("data", function (chunk) {
             stderr += chunk;
         });
 
         // pngquant changes the process from `convert < pixmap > fileStream`
         // to `convert < pixmap | pngquant > fileStream`
-        if (PNGQUANT_ENABLED && settings.format === "png" && settings.quality === "8") {
+        if (settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8) {
             var pngquantProc = runPngquant(psPath, ["-"]);
 
             pngquantProc.on("error", function (err) { onStreamError("Error with pngquant: " + err); });
@@ -223,14 +215,14 @@
             pngquantProc.stderr.on("error", function (err) { onStreamError("Error with pngquant's STDERR: " + err); });
 
             pngquantProc.stdout.pipe(fileStream);
-            imProc.stdout.pipe(pngquantProc.stdin);
+            convertProc.stdout.pipe(pngquantProc.stdin);
         } else {
             // Pipe convert's output (the produced image) into the file stream
-            imProc.stdout.pipe(fileStream);
+            convertProc.stdout.pipe(fileStream);
         }
 
         // Send the pixmap to convert
-        imProc.stdin.end(pixmap.pixels);
+        convertProc.stdin.end(pixmap.pixels);
 
         // Wait until convert is done (pipe from the last utility will close the stream)
         fileStream.on("close", function () {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1073,6 +1073,7 @@
      * @param {!String}  settings.format       ImageMagick output format
      * @param {?integer} settings.quality      A number indicating the quality - the meaning depends on the format
      * @param {?number}  settings.ppi          The image's pixel density
+     * @param {?boolean=} settings.usePngquant  If true, quantize 8-bit pngs using pngquant instead of convert
      */
     Generator.prototype.savePixmap = function (pixmap, path, settings) {
         var self    = this,


### PR DESCRIPTION
This freshens up @pornel 's contribution of a pngquant quantization pipeline for 8-bit pngs. It also adds an optional parameter to the `settings` object in `Generator.prototype.savePixmap` named `usePngquant` that enables the pngquant pipeline.

@pornel -- Thanks for the contribution! I made sure to incorporate your commit so that you get credit. :smile: However, I'm going to close #131 since I let that get waaaaay out of date and I can't update the branch that's in your repo. I really appreciate you bearing with us.

@iwehrman I've reviewed the code from @pornel but I've made a lot of changes. Could you give this a quick look?

This requires a recent Jenkins build of PS so that the pngquant binary is bundled.
