### PR TITLE
Always reject getPixmap promise upon unexpected PS response

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -807,7 +807,8 @@
             } else if (message.type === "pixmap") {
                 pixmapDeferred.resolve(message.value);
             } else {
-                _logger.warn("Unexpected response to getPixmap:", message);
+                _logger.warn("Unexpected response from Photoshop:", message);
+                executionDeferred.reject("Unexpected response from Photoshop");
             }
         });
 


### PR DESCRIPTION
In some cases, if we receive an unexpected response from Photoshop to a `getPixmap` request, the promise is neither resolved nor rejected. If clients are pipelining requests, as in the Image Assets plugin, this can block their execution. This pull request ensures that the promise is rejected upon receiving an unexpected response.

Please review ASAP @joelrbrandt.

CC @timothynoel 
