### PR TITLE
add getFullTextStyles and getDefaultLayerFX options to getDocumentInfo

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -407,13 +407,30 @@
      * @param {?integer} documentId Optional document ID
      * @param {?Object.<string, boolean>} flags Optional override of default flags for
      *   document info request. The optional flags and their default values are:
-     *          compInfo:             true
-     *          imageInfo:            true
-     *          layerInfo:            true
-     *          expandSmartObjects:   false
-     *          getTextStyles:        true
-     *          selectedLayers:       false
-     *          getCompLayerSettings: true
+     *
+     *   compInfo:             true
+     *   imageInfo:            true
+     *   layerInfo:            true
+     *     Specifies which info to send (image-specific, layer-specific, comp-specific)
+     *     If none of these is specified, all three default to true, otherwise it just
+     *     returns the true values
+     *   expandSmartObjects:   false
+     *     recurse into smart object (placed) documents
+     *   getTextStyles:        true
+     *     get limited text/style info for text layers. Returned in the "text" property of
+     *     layer info
+     *   getFullTextStyles:    false
+     *     get all text/style info for text layers. Returned in the "text" property of 
+     *     layer info, can be rather verbose
+     *   selectedLayers:       false
+     *     If true, only return details on the layers that the user has selected. If false,
+     *     all layers are returned
+     *   getCompLayerSettings: true
+     *     If true, send actual layer settings in comps (not just the comp ids, useVisibility,
+     *     usePosition, and useAppearance)
+     *   getDefaultLayerFX:    false
+     *     If true, send all fx settings for enabled fx, even if they match the defaults. If false
+     *     layer fx settings will only be sent if they are different from default settings.
      */
     Generator.prototype.getDocumentInfo = function (documentId, flags) {
         var params = {
@@ -424,8 +441,10 @@
                 layerInfo:            true,
                 expandSmartObjects:   false,
                 getTextStyles:        true,
+                getFullTextStyles:    false,
                 selectedLayers:       false,
-                getCompLayerSettings: true
+                getCompLayerSettings: true,
+                getDefaultLayerFX:    false
             }
         };
 


### PR DESCRIPTION
As it is currently implemented, the `getDocumentInfo` call only returns layer effects settings that differ from the default settings for each layer effect. If a layer effect is applied, but has all of the default settings, then `getDocumentInfo` just states that the layer effect is applied.

PS 14.2 added a `getDefaultLayerFX` option to the underlying KVLR `sendDocumentInfoToNetworkClient` command that we never bubbled up to the Generator API. This PR bubbles it up. It also opportunistically adds the `getFullTextStyles` option, and improves documentation of all of the options.

A bit more discussion on why this setting is useful:

Without turning this option on, the data reported for drop shadow effects (for example) can be confusing. By default, the drop shadow effect has "use global light" checked. So, changing the angle (with this box checked) changes the global light angle instead of anything in the layer effect, and it looks like the layer effect has completely default settings.

That change in angle is reported elsewhere in the document info as something like:

``` json
  "globalLight": {
    "angle": 147,
    "altitude": 30
  }
```

If you uncheck this box (and change the angle to something other than 120, which is the default) then you'll finally get something like this in the effects settings:

``` json
  "layerEffects": {
    "dropShadow": {
      "enabled": true,
      "useGlobalAngle": false,
      "localLightingAngle": {
        "value": 32,
        "units": "angleUnit"
      }
    }
  }
```

Anyway, if the user just sets `getDefaultLayerFX` to `true`, all becomes clear.
