### PR TITLE
rework handling of multiple js messages in getPixmap response

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -820,10 +820,12 @@
         executionDeferred = self._sendJSXFile("./jsx/getLayerPixmap.jsx", params);
 
         executionDeferred.promise.progress(function (message) {
-            if (message.type === "javascript" &&
-                    message.value instanceof Object &&
-                    message.value.hasOwnProperty("bounds")) {
-                jsDeferred.resolve(message.value);
+            if (message.type === "javascript") {
+                // We expect two javascript responses: one from the JSX evaluation result, and
+                // one containing bounds information. We only care about the bounds one.
+                if (message.value instanceof Object && message.value.hasOwnProperty("bounds")) {
+                    jsDeferred.resolve(message.value);
+                }
             } else if (message.type === "pixmap") {
                 pixmapDeferred.resolve(message.value);
             } else {


### PR DESCRIPTION
Addresses #240 (which also contains information on how to test).

See the comment at the beginning of getPixmap for an explanation of what's going on.

@iwehrman Apologies for missing this when reviewing #237.
