### PR TITLE
access PS version via reference (for merging into PR for issue 171)

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -348,7 +348,7 @@
      * @return {Promise.<string>} Resolves with the Photoshop version number.
      */
     Generator.prototype.getPhotoshopVersion = function () {
-        return this.evaluateJSXString("app.version");
+        return this.evaluateJSXFile("./jsx/getPhotoshopVersion.jsx", {});
     };
 
     Generator.prototype.addMenuItem = function (name, displayName, enabled, checked) {

--- a/lib/jsx/getPhotoshopVersion.jsx
+++ b/lib/jsx/getPhotoshopVersion.jsx
@@ -1,0 +1,22 @@
+/*global charIDToTypeID, stringIDToTypeID, ActionReference, executeAction, ActionDescriptor, DialogModes */
+
+var classProperty = charIDToTypeID("Prpr");
+var classApplication = charIDToTypeID("capp");
+var typeOrdinal = charIDToTypeID("Ordn");
+var enumTarget = charIDToTypeID("Trgt");
+var khostVersionStr = stringIDToTypeID("hostVersion");
+var typeNULL = charIDToTypeID("null");
+var actionGet = charIDToTypeID("getd");
+
+var desc = new ActionDescriptor();
+var ref = new ActionReference();
+ref.putProperty(classProperty, khostVersionStr);
+ref.putEnumerated(classApplication, typeOrdinal, enumTarget);
+desc.putReference(typeNULL, ref);
+var result = executeAction(actionGet, desc, DialogModes.NO);
+
+var versionObj = result.getObjectValue(khostVersionStr);
+var major = versionObj.getInteger(stringIDToTypeID("versionMajor"));
+var minor = versionObj.getInteger(stringIDToTypeID("versionMinor"));
+var fix = versionObj.getInteger(stringIDToTypeID("versionFix"));
+String(major + "." + minor + "." + fix);


### PR DESCRIPTION
This accesses the PS version via a reference rather than through `app.version`. The hope is that this will speed up startup a bit.

@iwehrman I can't consistently reproduce the slow startup situation that you were seeing. Can you test this?
