### PR TITLE
add private property to savePixmap settings to allow scaling with convert

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -35,11 +35,12 @@
         var args    = [],
             format  = settings.format,
             quality = settings.quality ? String(settings.quality) : null,
-            scale = settings.scale ? parseFloat(settings.scale) : 1.0;
+            _scale = settings._scale ? parseFloat(settings._scale) : 1.0;
 
-        
-        if (scale && scale !== 1.0) {
-            args.push("-resize", Math.round(scale * 100) + "%");
+        // Note: The _scale setting should be considered private and may be removed at any time
+        // with only a bump to the "patch" version number of generator-core. Use at your own risk.
+        if (_scale && _scale !== 1.0) {
+            args.push("-resize", Math.round(_scale * 100) + "%");
         }
         
         // Now perform color conversions

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1164,14 +1164,16 @@
      * @param {!String}  settings.format       ImageMagick output format
      * @param {?integer} settings.quality      A number indicating the quality - the meaning depends on the format
      * @param {?number}  settings.ppi          The image's pixel density
-     * @param {?number}  settings.scale        A scale factor that causes the image to be resized (optional)
+     * @param {?number}  settings._scale       A scale factor that causes the image to be resized using convert 
+     *    (This API should be considered private and may be removed at any time with only a bump to the "patch"
+     *    version number of generator-core. Use at your own risk.)
      * @param {?boolean=} settings.usePngquant  If true, quantize 8-bit pngs using pngquant instead of convert
      */
     Generator.prototype.savePixmap = function (pixmap, path, settings) {
         var convert = require("./convert");
 
-        if (settings.scale) {
-            settings.scale = parseFloat(settings.scale);
+        if (settings._scale) {
+            settings._scale = parseFloat(settings._scale);
         }
 
         // check that arguments are of the correct type


### PR DESCRIPTION
If a scale parameter is passed to convert, honor it.
