### PR TITLE
implement clipToDocumentBounds option to getPixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -829,6 +829,12 @@
      *     PS 15.0 and earlier pixel space scaling was the only option. So, setting this to "true" will replicate
      *     older behavior
      *     (Default: false))
+     * @param {?boolean} settings.clipToDocumentBounds: If true, crops returned pixels to the document bounds.
+     *     By default, all pixels for the specified layers are returned, even if they lie outside the document
+     *     bounds (e.g. if the document was cropped without "Delete Cropped Pixels" checked).
+     *     Note that this option *cannot* be used with an inputRect/outputRect scaling. If inputRect/outputRect
+     *     is set, this setting will be ignored and the pixels will not be cropped to document bounds.
+     *     (Default: false)
      * @param {number=} settings.compId Layer comp ID (exclusive of settings.compIndex)
      * @param {number=} settings.compIndex Layer comp index (exclusive of settings.compId)
      */
@@ -858,7 +864,8 @@
                 allowDither: settings.allowDither || false,
                 useColorSettingsDither: settings.useColorSettingsDither || false,
                 interpolationType: settings.interpolationType,
-                forceSmartPSDPixelScaling: settings.forceSmartPSDPixelScaling || false
+                forceSmartPSDPixelScaling: settings.forceSmartPSDPixelScaling || false,
+                clipToDocumentBounds: settings.clipToDocumentBounds || false
             };
 
         // Because of PS communication irregularities in different versions of PS, it's very complicated to

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -35,6 +35,12 @@
 //         (as opposed to scaling vectors, text, etc. in a smoother fashion.) In PS 15.0 and earlier
 //         pixel space scaling was the only option. So, setting this to "true" will replicate older behavior
 //         (Default: false)
+//   - clipToDocumentBounds: If true, crops returned pixels to the document bounds.
+//         By default, all pixels for the specified layers are returned, even if they lie outside the document
+//         bounds (e.g. if the document was cropped without "Delete Cropped Pixels" checked).
+//         Note that this option *cannot* be used with an inputRect/outputRect scaling. If inputRect/outputRect
+//         is set, this setting will be ignored and the pixels will not be cropped to document bounds.
+//         (Default: false)
 //   - compId: number, layer comp ID (optionally and exclusive of compIndex)
 //   - compIndex: number, layer comp index (optionally and exclusive of compId) 
 
@@ -194,6 +200,10 @@ actionDescriptor.putEnumerated(
 // the params properties).
 actionDescriptor.putBoolean(stringIDToTypeID("allowDither"), !!params.allowDither);
 actionDescriptor.putBoolean(stringIDToTypeID("useColorSettingsDither"), !!params.useColorSettingsDither);
+
+if (params.hasOwnProperty("clipToDocumentBounds")) {
+    actionDescriptor.putBoolean(stringIDToTypeID("clipToDocumentBounds"), !!params.clipToDocumentBounds);
+}
 
 if (params.boundsOnly) {
     actionDescriptor.putBoolean(stringIDToTypeID("boundsOnly"), params.boundsOnly);


### PR DESCRIPTION
Adds an optional (`false` by default) property to getPixmap's `settings` parameter called `clipToDocumentBounds`. If set to `true`, the resulting thumbnail is clipped to the document bounds. (Otherwise, in the default case, all pixels are returned, including those that might lie outside of the document bounds.)

**Important:** This will not work if an inputRect/outputRect scaling is specified. In that case, this property is ignored.

An easy way to test this is to comment out the inputRect/outputRect lines at the beginning of `getPixmap` (where `params` is constructed), and then set `params.clipToDocumentBounds` to `true`.

Addresses adobe-photoshop/generator-assets#255 and partially addresses adobe-photoshop/generator-assets#235

cc @nimbupani @jhatwich 
