### PR TITLE
First implementation of getStyleInfo

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -524,23 +524,25 @@
     };
 
     /**
+     * Get style information about a document.
+     *
+     * @param {number} documentId
+     * @param {?Object.<string, boolean>} flags Optional override of default flags for
+     *   document info request. The optional flags and their default values are:
+     *   
+     *   selectedLayers: false
+     *     If true, only return details on the layers that the user has selected. If false,
+     *     all layers are returned
+     *
+     * @return {Promise} resolves to the SON document for the specified Generator document
+     *
      * Note: This API should be considered private and may be changed/removed at any 
      * time with only a bump to the "patch" version number of generator-core. 
      * Use at your own risk.
-     *
-     * Get style information about a document.
-     * To find out about the current document, leave documentId empty.
-     * @param {?integer} documentId Optional document ID
-     * @param {?Object.<string, boolean>} flags Optional override of default flags for
-     *   document info request. The optional flags and their default values are:
-     *
-     *   
-     *   selectedLayers:       false
-     *     If true, only return details on the layers that the user has selected. If false,
-     *     all layers are returned
-     *   
      */
     Generator.prototype._getStyleInfo = function (documentId, flags) {
+        _logger.debug("called getStyleInfo for document", documentId);
+
         var documentInfoFlags = {
             compInfo:             true,
             imageInfo:            true,
@@ -551,13 +553,13 @@
             selectedLayers:       false,
             getCompLayerSettings: true,
             getDefaultLayerFX:    false
-          
         };
 
-        if (documentId === undefined) {
-            return Q.reject("Document ID is required");
-        } else {
+        documentId = parseInt(documentId, 10);
 
+        if (!isFinite(documentId)) {
+            return Q.reject("documentId parameter for _getStyleInfo must be an integer");
+        } else {
             var style = require("./style");
 
             if (flags && flags.hasOwnProperty("selectedLayers")) {

--- a/lib/style.js
+++ b/lib/style.js
@@ -409,7 +409,7 @@
 
     function getCSSName(layer) {
         // We want to convert the layer name to a valid CSS IDENT
-        var l = "layer" + layer.index; 
+        var l = "layer" + layer.index;
         var wsSequence = false;
 
         function _toClass(c) {
@@ -537,17 +537,16 @@
     }
 
     /**
+     * Return a SON document for the specified document info
+     *
+     * @param {Object} psd document retrieved from Generator.getDocumentInfo()
+     *
+     * @return {Object} The SON document for the specified Generator document 
+     *
      * Note: This API should be considered private and may be changed/removed at any 
      * time with only a bump to the "patch" version number of generator-core. 
      * Use at your own risk.
-     *
-     * Return a SON document for the specified document info
-     * @param {Object} document retrieved from Generator.getDocumentInfo()
-     *
-     * @returns {Object} The SON document for the specified Generator document 
      */
-   
-
     function extractStyleInfo(psd/*, opts*/) {
         var SON = {};
         var layers = psd.layers;
@@ -563,7 +562,6 @@
 
         return SON;
     }
-
 
     exports._extractStyleInfo = extractStyleInfo;
 }());


### PR DESCRIPTION
getStyleInfo returns a simplified JSON format to make it easier to convert to CSS
