### PR TITLE
experimental API for SVG

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1228,7 +1228,7 @@
     };
     
     /**
-     * Get an SVG representing the layer using svgOMG. Returns a promise that resolves to an SVG string.
+     * Get SVG for a layerSpec using svgObjectModelGenerator. Returns a promise that resolves to an SVG string.
      * The SVG can optionally be scaled proportionately using the "scale" parameter of the "settings" object
      * 
      * WARNING, This API is EXPERIMENTAL and is likely to change.  Breaking changes to this API will only 
@@ -1241,7 +1241,7 @@
      */
     Generator.prototype._getSVGOMG = function (documentId, layerSpec, settings) {
         
-        var svgOMG = require("svgomg"),
+        var svgOMG = require("svgobjectmodelgenerator"),
             scale = settings && settings.hasOwnProperty("scale") ? settings.scale : 1,
             params;
         
@@ -1253,7 +1253,7 @@
             documentId: documentId
         };
         
-        return svgOMG.getGeneratorSVG(this, params).then(function (result) { return decodeURI(result.svgText) });
+        return svgOMG.getGeneratorSVG(this, params).then(function (result) { return decodeURI(result.svgText); });
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "q": "~1.0",
     "semver": "~2.3",
     "ws": "git+https://github.com/adobe-photoshop/ws.git#v0.4.31-no-native",
-    "svgomg": "git+ssh://git@git.corp.adobe.com/jhatwich/svgomg.git"
+    "svgobjectmodelgenerator": "git+https://github.com/adobe-research/svgObjectModelGenerator.git#master"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Adds an experimental API to get SVG using https://github.com/adobe-research/svgObjectModelGenerator

There is a sister-PR for this for generator-assets.
