### PR TITLE
add convertToWorkingRGBProfile option to getPixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -854,6 +854,10 @@
      *     (confusingly) means that stroke effects (e.g. rounded rect corners) are *not* scaled. (Default: false)
      * @param {?boolean} settings.includeAncestorMasks Cause exported layer to be clipped by any ancestor masks
      *     that are visible (Default: false)
+     * @param {?boolean} settings.convertToWorkingRGBProfile: If true, performs a color conversion on the pixels
+     *     before they are sent to generator. The color is converted to the working RGB profile (specified for
+     *     the document in PS). By default (when this setting is false), the "raw" RGB data is sent, which is
+     *     what is usually desired. (Default: false)
      * @param {?boolean} settings.allowDither controls whether any dithering could possibly happen in the color
      *     conversion to 8-bit RGB. If false, then dithering will definitely not occur, regardless of either
      *     the value of useColorSettingsDither and the color settings in Photoshop. (Default: false)
@@ -902,6 +906,7 @@
                 boundsOnly: settings.boundsOnly,
                 useSmartScaling: settings.useSmartScaling || false,
                 includeAncestorMasks: settings.includeAncestorMasks || false,
+                convertToWorkingRGBProfile: settings.convertToWorkingRGBProfile || false,
                 allowDither: settings.allowDither || false,
                 useColorSettingsDither: settings.useColorSettingsDither || false,
                 interpolationType: settings.interpolationType,

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -20,6 +20,10 @@
 //         means that stroke effects (e.g. rounded rect corners) are *not* scaled. (Default: false)
 //   - includeAncestorMasks: setting to "true" causes exported layer to be clipped by any ancestor
 //         masks that are visible (Default: false)
+//   - convertToWorkingRGBProfile: If true, performs a color conversion on the pixels
+//         before they are sent to generator. The color is converted to the working RGB profile (specified for
+//         the document in PS). By default (when this setting is false), the "raw" RGB data is sent, which is
+//         what is usually desired. (Default: false)
 //   - allowDither: controls whether any dithering could possibly happen in the color conversion
 //         to 8-bit RGB. If false, then dithering will definitely not occur, regardless of either
 //         the value of useColorSettingsDither and the color settings in Photoshop. (Default: false)
@@ -193,6 +197,10 @@ actionDescriptor.putEnumerated(
     stringIDToTypeID("includeLayers"),
     stringIDToTypeID("includeVisible")
 );
+
+if (params.hasOwnProperty("convertToWorkingRGBProfile")) {
+    actionDescriptor.putBoolean(stringIDToTypeID("convertToWorkingRGBProfile"), !!params.convertToWorkingRGBProfile);
+}
 
 // NOTE: on the PS side, allowDither and useColorSettingsDither default to "true" if they are
 // not set at all. However, in Generator, the common case will be that we do NOT want to dither,


### PR DESCRIPTION
By default, generator dumps out "raw" RGB values to pixmaps. If the document uses a color profile other than sRGB, this will result in output that looks different than the PSD (since the output doesn't have a color profile and the user's system will probably use sRGB to interpret it.)

Most of the time, web designers don't color manage their documents, so Generator usually does what they want. But, there's an option in `sendLayerThumbnail` that enables color conversion in these non-standard use cases. This pull request bubbles that option up to getPixmap.

A PR in generator-assets is forthcoming that adds a config option to leverage this. Automated tests are also forthcoming.

I thought this was what @dirkschulze was asking for in #249 but it turns out it isn't. So, I don't think anyone actually wants this. So, I spent my weekend implementing it -- I endeavor to make potential future users happy instead of current users.

@iwehrman maybe you can spend your weekend reviewing it!
