### PR TITLE
Implemented generator.getDocumentPixmap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1042,7 +1042,7 @@
                 hiddenLayers = hiddenLayers.concat(this._computeHiddenLayers(layer, isHidden));
             }
             return hiddenLayers;
-        }, []);
+        }.bind(this), []);
     };
 
     /**


### PR DESCRIPTION
My attempt to solve export of document as one pixmap.

Minimal usage example (and test code) is here: https://github.com/marekhrabe/document-export. The example, immediately after initialization, gets `activeDocument.id` and calls `getDocumentPixmap` with that id and blank settings. It generates `document-pixmap.png` to current path.

Now it's on you to do the review :) 
