### PR TITLE
Added lossless option for saving webp

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -29,14 +29,13 @@
 
     // Constants
     var DEFAULT_IMAGE_QUALITY           = 90,
-        BACKGROUND_COLOR_FOR_FLATTENING = "#fff",
-        LOSSLESS_BY_DEFAULT = true;
+        BACKGROUND_COLOR_FOR_FLATTENING = "#fff";
 
     function getConvertArgumentsForSettings(settings, binaryPaths) {
         var args    = [],
             format  = settings.format,
             quality = settings.quality ? String(settings.quality) : null,
-            lossless = settings.lossless !== undefined ? Boolean(settings.lossless) : LOSSLESS_BY_DEFAULT,
+            lossless = settings.lossless,
             _scale = settings._scale ? parseFloat(settings._scale) : 1.0;
 
         // Note: The _scale setting should be considered private and may be removed at any time
@@ -93,7 +92,9 @@
             args.push("-quality", quality);
         }
         if (format === "webp") {
-            args.push("-define", "webp:lossless=" + lossless);
+            if (lossless !== undefined) {
+                args.push("-define", "webp:lossless=" + Boolean(lossless));
+            }
         }
 
         return args;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1275,7 +1275,7 @@
      * @param {!Object}  settings              An object with settings for converting the image
      * @param {!String}  settings.format       ImageMagick output format
      * @param {?integer} settings.quality      A number indicating the quality - the meaning depends on the format
-     * @param {?boolean} settings.lossless     Lossless compression for webp format (true by default)
+     * @param {?boolean} settings.lossless     Lossless compression for webp format
      * @param {?number}  settings.ppi          The image's pixel density
      * @param {?number}  settings._scale       A scale factor that causes the image to be resized using convert 
      *    (This API should be considered private and may be removed at any time with only a bump to the "patch"


### PR DESCRIPTION
Webp has two main options in ImageMagick - `quality` (0-100) and if compression is `lossless`. I added latter as an option of `savePixmap`. I'm just not sure about the default value and communicating that - what do you think?
