### PR TITLE
Fix bounds computation when the padding is entirely due to effects and not to masking

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1247,9 +1247,11 @@
                 var // How much padding is necessary in both dimensions
                     missingWidth  = paddedOutputWidth  - pixmapWidth,
                     missingHeight = paddedOutputHeight - pixmapHeight,
-                    // How of the original padding was on which side (default 0 to counteract NaN)
-                    leftRatio     = ((visibleInputBounds.left - paddedInputBounds.left) / paddingInputWidth)  || 0,
-                    topRatio      = ((visibleInputBounds.top  - paddedInputBounds.top)  / paddingInputHeight) || 0,
+                    // How of the original padding was on which side (default 0)
+                    leftRatio     = paddingInputWidth === 0 ? 0 :
+                        ((visibleInputBounds.left - paddedInputBounds.left) / paddingInputWidth),
+                    topRatio      = paddingInputHeight === 0 ? 0 :
+                        ((visibleInputBounds.top  - paddedInputBounds.top)  / paddingInputHeight),
                     // Concrete padding size on one side so the other side can use the rest
                     leftPadding   = Math.round(leftRatio * missingWidth),
                     topPadding    = Math.round(topRatio  * missingHeight);


### PR DESCRIPTION
... or something like that. I really don't have any idea what's going on here at a high level, only that there's a broken JavaScript idiom [here](https://github.com/adobe-photoshop/generator-core/blob/d37bd18052b10a7e6c001b007c17aa18c7c6cefb/lib/generator.js#L1251-L1252) for dealing with a divide-by-zero. The code in question looks like this:

```
foo = (bar / baz) || 0
```

where the disjunction is supposed to provide for a default value of zero in case `baz === 0`. The assumption is that `bar/0 === NaN` for then `NaN || 0 === 0`. But, in fact, `bar/0 === Infinity`, and `Infinity || 0 === Infinity`. After additional math, this `Infinity` turns into a `NaN` and finds its way into a `convert` parameter, which causes a `savePixmap` call to fail.

This happens only on Windows. I don't immediately know why. It _may_ be related to the fact that Photoshop seems to be returning non-integral bounds from `Generator.prototype.getPixmap` with the `boundsOnly` setting enabled; in particular, it seems to be returning a number extremely close to but not zero. (@timothynoel, is this expected!?) But that's just a totally wild guess based on my surprise at finding a float where an integer was expected. 

This bounds code is known to be crazy and in need of a rewrite, so, should I spend any more time on this now? 
![no](http://f.cl.ly/items/2l1p1s1d1r372p02401T/Photo%20Aug%2006,%2010%2018%2020%20PM.gif)

Conceivably, this addresses adobe-photoshop/generator-assets#259. @AlicanC if you're feeling bored and/or brave, you could let me know if this fixes your problem!

Have fun reviewing, @joelrbrandt!
