### PR TITLE
Added getPathData flag to getDocumentInfo

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -495,6 +495,9 @@
      *   getDefaultLayerFX:    false
      *     If true, send all fx settings for enabled fx, even if they match the defaults. If false
      *     layer fx settings will only be sent if they are different from default settings.
+     *   getPathData:    false
+     *     If true, shapeLayers will include detaled about their path data (in the same
+     *     format at generator.getLayerShape)
      */
     Generator.prototype.getDocumentInfo = function (documentId, flags) {
         var params = {
@@ -508,7 +511,8 @@
                 getFullTextStyles:    false,
                 selectedLayers:       false,
                 getCompLayerSettings: true,
-                getDefaultLayerFX:    false
+                getDefaultLayerFX:    false,
+                getPathData:          false
             }
         };
 


### PR DESCRIPTION
We use this for a while in Avocode and we needed custom getDocumentInfo implementation for that. It should be included in main repo, right? Or is there a reason why it is not yet there?
