### PR TITLE
Implemented saving pixmap with 1 or 3 channels

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -109,11 +109,14 @@
         var args = [
             // In order to know the pixel boundaries, ImageMagick needs to know the resolution and pixel depth
             "-size", pixmap.width + "x" + pixmap.height,
-            "-depth", pixmap.bitsPerChannel,
-            // pixmap.pixels contains the pixels in ARGB format, but ImageMagick only understands RGBA
-            // The color-matrix parameter allows us to compensate for that
-            "-color-matrix", "0 1 0 0, 0 0 1 0, 0 0 0 1, 1 0 0 0"
+            "-depth", pixmap.bitsPerChannel
         ];
+
+        if (pixmap.channelCount === 4) {
+            // pixmap.pixels may contain the pixels in ARGB format, but ImageMagick only understands RGBA
+            // The color-matrix parameter allows us to compensate for that
+            args.push("-color-matrix", "0 1 0 0, 0 0 1 0, 0 0 0 1, 1 0 0 0");
+        }
 
         if (!isNaN(settings.ppi)) {
             // Pass information about the image's pixel density
@@ -122,8 +125,18 @@
             console.warn("Did not pass the document's resolution because it is not a valid number:", settings.ppi);
         }
 
-        // Read the pixels in RGBA form from STDIN
-        args.push("rgba:-");
+        // Read the pixels in appropriate format form from STDIN
+        switch (pixmap.channelCount) {
+        case 1:
+            args.push("gray:-");
+            break;
+        case 3:
+            args.push("rgb:-");
+            break;
+        case 4:
+            args.push("rgba:-");
+            break;
+        }
 
         var padding = settings.padding;
         if (padding) {


### PR DESCRIPTION
Only place that needed change was the convert implementation, other things look ready. I tested with "synthetic" pixmaps like this one:

``` js
var pixels = new Buffer(400);
pixels.fill(0xcc);

var pixmap = { format: 2,
  width: 20,
  height: 20,
  rowBytes: 20,
  colorMode: 1,
  channelCount: 1,
  bitsPerChannel: 8,
  pixels: pixels,
  bytesPerPixel: 1,
  bounds: { top: 0, left: 0, bottom: 20, right: 20 }
};

generator.savePixmap(pixmap, 'pixmap.png', { format: 'gif', ppi: 72 });
```

This should make it easier to implement mask support as discussed in https://github.com/adobe-photoshop/generator-core/issues/161#issuecomment-56403631

I tested output to png, gif and jpg and all seems working perfectly.
