### PR TITLE
use 127.0.0.1 instead of localhost incase hosts file is messed up

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@
 
     var optionParser = optimist["default"]({
         "p" : 49494,
-        "h" : "localhost",
+        "h" : "127.0.0.1",
         "P" : "password",
         "i" : null,
         "o" : null,

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -39,7 +39,7 @@
     // Connection constants
     var DEFAULT_PASSWORD       = "password",
         DEFAULT_PORT           = 49494,
-        DEFAULT_HOSTNAME       = "localhost",
+        DEFAULT_HOSTNAME       = "127.0.0.1",
         SOCKET_KEEPALIVE_DELAY = 1000; //milliseconds
 
     var CONNECTION_STATES = {


### PR DESCRIPTION
We've had a few complaints about crema not working on some machines. In those cases it turned out the users  "hosts" file was generally messed up in a way that "localhost" was no longer defined. Instead just use the loopback address directly to avoid the problem.

Please merge this into the 15.2.2 release too.
