### PR TITLE
Add option to extract part of the image.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -104,6 +104,9 @@
     function savePixmap(binaryPaths, pixmap, path, settings) {
         var fileCompleteDeferred = Q.defer(),
             fs  = require("fs");
+        
+        var finalWidth = pixmap.width,
+            finalHeight = pixmap.height;
 
         // Define the input
         var args = [
@@ -122,19 +125,26 @@
             console.warn("Did not pass the document's resolution because it is not a valid number:", settings.ppi);
         }
 
+        if (settings.extract && Number.isFinite(settings.extract.width) && settings.extract.width > 0 &&
+                                Number.isFinite(settings.extract.height) && settings.extract.height > 0) {
+            finalWidth = settings.extract.width;
+            finalHeight = settings.extract.height;
+            args.push("-extract", finalWidth + "x" + finalHeight + "+" + settings.extract.x + "+" + settings.extract.y);
+        }
+
         // Read the pixels in RGBA form from STDIN
         args.push("rgba:-");
 
         var padding = settings.padding;
         if (padding) {
             // Calculate the new image size
-            var newWidth  = pixmap.width  + padding.left + padding.right,
-                newHeight = pixmap.height + padding.top  + padding.bottom;
+            finalWidth  = finalWidth  + padding.left + padding.right;
+            finalHeight = finalHeight + padding.top  + padding.bottom;
 
             // Use a transparent background color ("transparent" doesn't work because Colors.xml is missing)
             args.push("-background", "rgba(0,0,0,0)");
             // Set the canvas size and position the image inside of it
-            args.push("-extent", newWidth + "x" + newHeight + "-" + padding.left + "-" + padding.top);
+            args.push("-extent", finalWidth + "x" + finalHeight + "-" + padding.left + "-" + padding.top);
         }
 
         // Define conversions

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1105,6 +1105,53 @@
 
         return resultDeferred.promise;
     };
+    
+    Generator.prototype._isBoundEmpty = function (bounds) {
+        var height = bounds.bottom - bounds.top,
+            width = bounds.right - bounds.left;
+        
+        return !(Number.isFinite(height) && Number.isFinite(width) &&
+                width > 0 && height > 0);
+    };
+    
+    Generator.prototype._unionBounds = function (boundsA, boundsB) {
+        return {
+            top: Math.min(boundsA.top, boundsB.top),
+            left: Math.min(boundsA.left, boundsB.left),
+            bottom: Math.max(boundsA.bottom, boundsB.bottom),
+            right: Math.max(boundsA.right, boundsB.right)
+        };
+    };
+    
+    Generator.prototype._intersectBounds = function (boundsA, boundsB) {
+        var intersect = {
+                top: Math.max(boundsA.top, boundsB.top),
+                left: Math.max(boundsA.left, boundsB.left),
+                bottom: Math.min(boundsA.bottom, boundsB.bottom),
+                right: Math.min(boundsA.right, boundsB.right)
+            };
+        
+        if (this._isBoundEmpty(intersect)) {
+            intersect = {top: 0, left: 0, bottom: 0, right: 0};
+        }
+        return intersect;
+    };
+    
+    Generator.prototype._getTotalMaskBounds = function (bounds) {
+        var maskBounds = bounds.mask && bounds.mask.enabled && bounds.mask.bounds,
+            vectorMaskBounds = bounds.type !== "shapeLayer" && bounds.path && bounds.path.bounds;
+        if (maskBounds && this._isBoundEmpty(maskBounds)) {
+            maskBounds = undefined;
+        }
+        if (vectorMaskBounds && this._isBoundEmpty(vectorMaskBounds)) {
+            vectorMaskBounds = undefined;
+        }
+        if (maskBounds && vectorMaskBounds) {
+            return this._unionBounds(maskBounds, vectorMaskBounds);
+        }
+        
+        return maskBounds || vectorMaskBounds;
+    };
 
     Generator.prototype.getDeepBounds = function (layer) {
         var bounds;
@@ -1119,26 +1166,17 @@
                     if (!bounds) {
                         bounds = childBounds;
                     } else {
-                        bounds = { // Compute containing rect of union of bounds and childBounds
-                            left:   Math.min(bounds.left,   childBounds.left),
-                            top:    Math.min(bounds.top,    childBounds.top),
-                            right:  Math.max(bounds.right,  childBounds.right),
-                            bottom: Math.max(bounds.bottom, childBounds.bottom)
-                        };
+                        // Compute containing rect of union of bounds and childBounds
+                        bounds = this._unionBounds(bounds, childBounds);
                     }
                 }
             }, this);
         }
 
-        if (layer.mask && layer.mask.bounds) {
-            var maskBounds = layer.mask.bounds;
-            
-            bounds = { // compute containing rect of intersection of bounds and maskBounds
-                left:   Math.max(bounds.left,   maskBounds.left),
-                top:    Math.max(bounds.top,    maskBounds.top),
-                right:  Math.min(bounds.right,  maskBounds.right),
-                bottom: Math.min(bounds.bottom, maskBounds.bottom)
-            };
+        var maskBounds = this._getTotalMaskBounds(layer);
+        if (maskBounds) {
+            // compute containing rect of intersection of bounds and maskBounds
+            bounds = this._intersectBounds(bounds, maskBounds);
         }
 
         return bounds;
@@ -1164,10 +1202,11 @@
      * @param {!Object<String,float>} paddedInputBounds  Bounds for the whole image (visible + padding)
      */
     Generator.prototype.getPixmapParams = function (settings,
-        staticInputBounds, visibleInputBounds, paddedInputBounds) {
+        staticInputBounds, visibleInputBounds, paddedInputBounds, clipToBounds) {
         
         // For backwards compatibility
         paddedInputBounds = paddedInputBounds || visibleInputBounds;
+        clipToBounds = clipToBounds || paddedInputBounds;
 
         var // Scaling settings
             targetWidth         = settings.width,
@@ -1276,6 +1315,91 @@
                     right:  missingWidth  - leftPadding,
                     bottom: missingHeight - topPadding
                 };
+            },
+            
+            getExtractParamsForDocBounds: function (finalWidth, finalHeight) {
+                //if the image and effects are completely contained there is nothing more to do
+                if (paddedInputBounds.top >= clipToBounds.top && paddedInputBounds.top <= clipToBounds.bottom &&
+                    paddedInputBounds.left >= clipToBounds.left && paddedInputBounds.left <= clipToBounds.right &&
+                    paddedInputBounds.right <= clipToBounds.right && paddedInputBounds.right >= clipToBounds.left &&
+                    paddedInputBounds.bottom <= clipToBounds.bottom && paddedInputBounds.bottom >= clipToBounds.top) {
+                    return;
+                }
+                
+                //if the image and effects are completely outside there is nothing to extract
+                if (paddedInputBounds.top > clipToBounds.bottom || paddedInputBounds.left > clipToBounds.right ||
+                    paddedInputBounds.right < clipToBounds.left || paddedInputBounds.bottom < clipToBounds.top) {
+                    return {x:0, y:0, height: 0, width: 0};
+                }
+                
+                var deltaTop = 0,
+                    deltaLeft = 0,
+                    deltaRight = 0,
+                    deltaBottom = 0,
+                    clipDeltaTop = Math.abs(Math.min(0, paddedInputBounds.top - clipToBounds.top)),
+                    clipDeltaLeft = Math.abs(Math.min(0, paddedInputBounds.left - clipToBounds.left)),
+                    clipDeltaRight = Math.abs(Math.min(0, clipToBounds.right - paddedInputBounds.right)),
+                    clipDeltaBottom = Math.abs(Math.min(0, clipToBounds.bottom - paddedInputBounds.bottom));
+                
+                var calcScaledDelta = function (clipDelta, staticDelta, effectsDelta, paddingDelta, scale) {
+                    var finalDelta = 0;
+                    if (effectsScaled) {
+                        finalDelta = clipDelta * scale;
+                    } else {
+                        finalDelta = Math.min(staticDelta, clipDelta) * scale;
+                        clipDeltaTop = Math.max(0, clipDelta - staticDelta);
+                        finalDelta += Math.min(effectsDelta, clipDelta);
+                        clipDeltaTop = Math.max(0, clipDelta - staticDelta);
+                        finalDelta += Math.min(paddingDelta, clipDelta);
+                    }
+                    
+                    return finalDelta;
+                };
+                
+                //if we're cropping include any padding and effects on that side
+                if (clipDeltaTop) {
+                    var staticDeltaTop = Math.abs(Math.min(0, staticInputBounds.top - clipToBounds.top)),
+                        effectsDeltaTop = staticInputBounds.top - visibleInputBounds.top,
+                        paddingDeltaTop = visibleInputBounds.top - paddedInputBounds.top;
+
+                    deltaTop = calcScaledDelta(clipDeltaTop, staticDeltaTop, effectsDeltaTop,
+                                               paddingDeltaTop, scaleY);
+                }
+                
+                if (clipDeltaLeft) {
+                    var staticDeltaLeft = Math.abs(Math.min(0, staticInputBounds.left - clipToBounds.left)),
+                        effectsDeltaLeft = staticInputBounds.left - visibleInputBounds.left,
+                        paddingDeltaLeft = visibleInputBounds.left - paddedInputBounds.left;
+                    
+                    deltaLeft = calcScaledDelta(clipDeltaLeft, staticDeltaLeft, effectsDeltaLeft,
+                                                paddingDeltaLeft, scaleX);
+                }
+                
+                if (clipDeltaRight) {
+                    var staticDeltaRight = Math.abs(Math.min(0, clipToBounds.right - staticInputBounds.right)),
+                        effectsDeltaRight = visibleInputBounds.right - staticInputBounds.right,
+                        paddingDeltaRight = paddedInputBounds.right - visibleInputBounds.right;
+                    
+                    deltaRight = calcScaledDelta(clipDeltaRight, staticDeltaRight, effectsDeltaRight,
+                                                 paddingDeltaRight, scaleX);
+                }
+                
+                if (clipDeltaBottom) {
+                    var staticDeltaBottom = Math.abs(Math.min(0, clipToBounds.bottom - staticInputBounds.bottom)),
+                        effectsDeltaBottom = visibleInputBounds.bottom - staticInputBounds.bottom,
+                        paddingDeltaBottom = paddedInputBounds.bottom - visibleInputBounds.bottom;
+                    
+                    deltaBottom = calcScaledDelta(clipDeltaBottom, staticDeltaBottom, effectsDeltaBottom,
+                                                  paddingDeltaBottom, scaleY);
+                }
+                
+                return {
+                    x: Math.round(deltaLeft),
+                    y: Math.round(deltaTop),
+                    width: Math.round(finalWidth - deltaLeft - deltaRight),
+                    height: Math.round(finalHeight - deltaTop - deltaBottom)
+                };
+                
             }
         };
     };
@@ -1295,6 +1419,9 @@
      * @param {?Object}  settings.padding      Padding, in pixels, to add around the saved image. Should have the
      *    format { top: 0, left: 0, bottom: 0, right: 0 }. Padding will be transparent (for formats that support
      *    transparency) or white.
+     * @param {?Object}  settings.extract      Extract, coorindates and size to extract from the pixmap. Should have
+     *    ths format { x: number, y: number, height: number, width number }. All numbers should be positive. X and Y 
+     *    can be 0, width and height cannot
      * @param {?number}  settings._scale       A scale factor that causes the image to be resized using convert 
      *    (This API should be considered private and may be removed at any time with only a bump to the "patch"
      *    version number of generator-core. Use at your own risk.)


### PR DESCRIPTION
Supports clipping to document bounds

This is ready to go, and is required by adobe-photoshop/generator-assets#315

This adds the options to calculate the area to extract if you want to clip to the document bounds (or any clipTo bounds you want to use)

Please merge to 15.2.2
