### PR TITLE
Add generator.streamPixmap, for writing a pixmap to a stream.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -159,6 +159,21 @@
         return args;
     }
 
+    function _rejectDeferredOnProcessIOError(process, processName, deferred) {
+        process.on("error", function (err) {
+            deferred.reject("Error with " + processName + ": " + err);
+        });
+        process.stdin.on("error",  function (err) {
+            deferred.reject("Error with " + processName + "'s STDIN: "  + err);
+        });
+        process.stdout.on("error", function (err) {
+            deferred.reject("Error with " + processName + "'s STDOUT: " + err);
+        });
+        process.stderr.on("error", function (err) {
+            deferred.reject("Error with " + processName + "'s STDERR: " + err);
+        });
+    }
+
     function _shouldUsePNGQuant(settings) {
         return settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8;
     }
@@ -166,18 +181,7 @@
     function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, outputCompleteDeferred) {
         var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
 
-        pngquantProc.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with pngquant: " + err);
-        });
-        pngquantProc.stdin.on("error",  function (err) {
-            outputCompleteDeferred.reject("Error with pngquant's STDIN: "  + err);
-        });
-        pngquantProc.stdout.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with pngquant's STDOUT: " + err);
-        });
-        pngquantProc.stderr.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with pngquant's STDERR: " + err);
-        });
+        _rejectDeferredOnProcessIOError(pngquantProc, "pngquant", outputCompleteDeferred);
 
         pngquantProc.stdout.pipe(outputStream);
         inputStream.pipe(pngquantProc.stdin);
@@ -193,21 +197,7 @@
         var convertProc = spawn(binaryPaths.convert, args);
 
         // Handle errors
-        convertProc.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with convert: " + err);
-        });
-        convertProc.stdin.on("error",  function (err) {
-            outputCompleteDeferred.reject("Error with convert's STDIN: "  + err);
-        });
-        convertProc.stdout.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with convert's STDOUT: " + err);
-        });
-        convertProc.stderr.on("error", function (err) {
-            outputCompleteDeferred.reject("Error with convert's STDERR: " + err);
-        });
-        outputStream.on("error",  function (err) {
-            outputCompleteDeferred.reject("Error with pixmap output stream: " + err);
-        });
+        _rejectDeferredOnProcessIOError(convertProc, "convert", outputCompleteDeferred);
 
         // Capture STDERR
         var stderr = "";

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -163,22 +163,21 @@
         return settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8;
     }
 
-    function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, onStreamError) {
+    function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, outputCompleteDeferred) {
         var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
 
-        pngquantProc.on("error", function (err) { onStreamError("Error with pngquant: " + err); });
-        pngquantProc.stdin.on("error",  function (err) { onStreamError("Error with pngquant's STDIN: "  + err); });
-        pngquantProc.stdout.on("error", function (err) { onStreamError("Error with pngquant's STDOUT: " + err); });
-        pngquantProc.stderr.on("error", function (err) { onStreamError("Error with pngquant's STDERR: " + err); });
+        pngquantProc.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant: " + err); });
+        pngquantProc.stdin.on("error",  function (err) { outputCompleteDeferred.reject("Error with pngquant's STDIN: "  + err); });
+        pngquantProc.stdout.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant's STDOUT: " + err); });
+        pngquantProc.stderr.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant's STDERR: " + err); });
 
         pngquantProc.stdout.pipe(outputStream);
         inputStream.pipe(pngquantProc.stdin);
     }
 
     // Exported functions
-    function streamPixmap(binaryPaths, pixmap, outputStream, settings, onStreamError) {
-        var outputCompleteDeferred = Q.defer(),
-            fs  = require("fs");
+    function streamPixmap(binaryPaths, pixmap, outputStream, settings) {
+        var outputCompleteDeferred = Q.defer();
 
         var args = _getConvertArguments(binaryPaths, pixmap, settings);
 
@@ -186,11 +185,11 @@
         var convertProc = spawn(binaryPaths.convert, args);
 
         // Handle errors
-        convertProc.on("error", function (err) { onStreamError("Error with convert: " + err); });
-        convertProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
-        convertProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
-        convertProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
-        outputStream.on("error",  function (err) { onStreamError("Error with pixmap output stream: " + err); });
+        convertProc.on("error", function (err) { outputCompleteDeferred.reject("Error with convert: " + err); });
+        convertProc.stdin.on("error",  function (err) { outputCompleteDeferred.reject("Error with convert's STDIN: "  + err); });
+        convertProc.stdout.on("error", function (err) { outputCompleteDeferred.reject("Error with convert's STDOUT: " + err); });
+        convertProc.stderr.on("error", function (err) { outputCompleteDeferred.reject("Error with convert's STDERR: " + err); });
+        outputStream.on("error",  function (err) { outputCompleteDeferred.reject("Error with pixmap output stream: " + err); });
 
         // Capture STDERR
         var stderr = "";
@@ -201,7 +200,7 @@
         // pngquant changes the process from `convert < pixmap > outputStream`
         // to `convert < pixmap | pngquant > outputStream`
         if (_shouldUsePNGQuant(settings)) {
-            _pipeThroughPNGQuant(binaryPaths, convertProc.stdout, outputStream, onStreamError);
+            _pipeThroughPNGQuant(binaryPaths, convertProc.stdout, outputStream, outputCompleteDeferred);
         } else {
             // Pipe convert's output (the produced image) into the output stream
             convertProc.stdout.pipe(outputStream);
@@ -223,33 +222,28 @@
     }
 
     function savePixmap(binaryPaths, pixmap, path, settings) {
-        var fs  = require("fs");
+        var fs = require("fs");
 
-        // Setup a file stream to the output file
+        // Open a stream to the output file.
         var fileStream = fs.createWriteStream(path);
-        fileStream.on("error", function (err) {
-            fileCompleteDeferred.reject("Could not create write stream for file " + path + ": " + err);
-        });
-
-        function onStreamError(err) {
-            try {
-                fileStream.close();
-            } catch (e) {
-                console.error("Error when closing file stream", e);
-            }
-            try {
-                if (fs.existsSync(path)) {
-                    fs.unlinkSync(path);
-                }
-            } catch (e) {
-                console.error("Error when deleting file", path, e);
-            }
-            fileCompleteDeferred.reject(err);
-        }
 
         // Stream the pixmap into the file and resolve with path when successful.
-        return streamPixmap(binaryPaths, pixmap, fileStream, settings, onStreamError)
-            .thenResolve(path);
+        return streamPixmap(binaryPaths, pixmap, fileStream, settings)
+            .thenResolve(path)
+            .catch(function(err) {
+                try {
+                    fileStream.close();
+                } catch (e) {
+                    console.error("Error when closing file stream", e);
+                }
+                try {
+                    if (fs.existsSync(path)) {
+                        fs.unlinkSync(path);
+                    }
+                } catch (e) {
+                    console.error("Error when deleting file", path, e);
+                }
+            });
     }
 
     exports.streamPixmap = streamPixmap;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -166,10 +166,18 @@
     function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, outputCompleteDeferred) {
         var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
 
-        pngquantProc.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant: " + err); });
-        pngquantProc.stdin.on("error",  function (err) { outputCompleteDeferred.reject("Error with pngquant's STDIN: "  + err); });
-        pngquantProc.stdout.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant's STDOUT: " + err); });
-        pngquantProc.stderr.on("error", function (err) { outputCompleteDeferred.reject("Error with pngquant's STDERR: " + err); });
+        pngquantProc.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with pngquant: " + err);
+        });
+        pngquantProc.stdin.on("error",  function (err) {
+            outputCompleteDeferred.reject("Error with pngquant's STDIN: "  + err);
+        });
+        pngquantProc.stdout.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with pngquant's STDOUT: " + err);
+        });
+        pngquantProc.stderr.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with pngquant's STDERR: " + err);
+        });
 
         pngquantProc.stdout.pipe(outputStream);
         inputStream.pipe(pngquantProc.stdin);
@@ -185,11 +193,21 @@
         var convertProc = spawn(binaryPaths.convert, args);
 
         // Handle errors
-        convertProc.on("error", function (err) { outputCompleteDeferred.reject("Error with convert: " + err); });
-        convertProc.stdin.on("error",  function (err) { outputCompleteDeferred.reject("Error with convert's STDIN: "  + err); });
-        convertProc.stdout.on("error", function (err) { outputCompleteDeferred.reject("Error with convert's STDOUT: " + err); });
-        convertProc.stderr.on("error", function (err) { outputCompleteDeferred.reject("Error with convert's STDERR: " + err); });
-        outputStream.on("error",  function (err) { outputCompleteDeferred.reject("Error with pixmap output stream: " + err); });
+        convertProc.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with convert: " + err);
+        });
+        convertProc.stdin.on("error",  function (err) {
+            outputCompleteDeferred.reject("Error with convert's STDIN: "  + err);
+        });
+        convertProc.stdout.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with convert's STDOUT: " + err);
+        });
+        convertProc.stderr.on("error", function (err) {
+            outputCompleteDeferred.reject("Error with convert's STDERR: " + err);
+        });
+        outputStream.on("error",  function (err) {
+            outputCompleteDeferred.reject("Error with pixmap output stream: " + err);
+        });
 
         // Capture STDERR
         var stderr = "";
@@ -230,7 +248,7 @@
         // Stream the pixmap into the file and resolve with path when successful.
         return streamPixmap(binaryPaths, pixmap, fileStream, settings)
             .thenResolve(path)
-            .catch(function(err) {
+            .catch(function (err) {
                 // If an error occurred, clean up the file.
                 try {
                     fileStream.close();

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -190,7 +190,7 @@
         convertProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
         convertProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
         convertProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
-        outputStream.on("error",  function (err) { onStreamError("Error with stream pixmap output stream: " + err); });
+        outputStream.on("error",  function (err) { onStreamError("Error with pixmap output stream: " + err); });
 
         // Capture STDERR
         var stderr = "";

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -252,5 +252,6 @@
             .thenResolve(path);
     }
 
+    exports.streamPixmap = streamPixmap;
     exports.savePixmap = savePixmap;
 }());

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -31,7 +31,7 @@
     var DEFAULT_IMAGE_QUALITY           = 90,
         BACKGROUND_COLOR_FOR_FLATTENING = "#fff";
 
-    function getConvertArgumentsForSettings(settings, binaryPaths) {
+    function _getConvertArgumentsForSettings(settings, binaryPaths) {
         var args    = [],
             format  = settings.format,
             quality = settings.quality ? String(settings.quality) : null,
@@ -100,11 +100,7 @@
         return args;
     }
 
-    // Exported functions
-    function savePixmap(binaryPaths, pixmap, path, settings) {
-        var fileCompleteDeferred = Q.defer(),
-            fs  = require("fs");
-        
+    function _getConvertArguments(binaryPaths, pixmap, settings) {
         var finalWidth = pixmap.width,
             finalHeight = pixmap.height;
 
@@ -148,7 +144,7 @@
         }
 
         // Define conversions
-        args = args.concat(getConvertArgumentsForSettings(settings, binaryPaths));
+        args = args.concat(_getConvertArgumentsForSettings(settings, binaryPaths));
 
         // Define the output
         var format = settings.format;
@@ -159,6 +155,33 @@
 
         // Write an image of format <format> to STDOUT
         args.push(format + ":-");
+
+        return args;
+    }
+
+    function _shouldUsePNGQuant(settings) {
+        return true;
+        return settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8;
+    }
+
+    function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, onStreamError) {
+        var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
+
+        pngquantProc.on("error", function (err) { onStreamError("Error with pngquant: " + err); });
+        pngquantProc.stdin.on("error",  function (err) { onStreamError("Error with pngquant's STDIN: "  + err); });
+        pngquantProc.stdout.on("error", function (err) { onStreamError("Error with pngquant's STDOUT: " + err); });
+        pngquantProc.stderr.on("error", function (err) { onStreamError("Error with pngquant's STDERR: " + err); });
+
+        pngquantProc.stdout.pipe(outputStream);
+        inputStream.pipe(pngquantProc.stdin);
+    }
+
+    // Exported functions
+    function savePixmap(binaryPaths, pixmap, path, settings) {
+        var fileCompleteDeferred = Q.defer(),
+            fs  = require("fs");
+
+        var args = _getConvertArguments(binaryPaths, pixmap, settings);
 
         // Setup a file stream to the output file
         var fileStream = fs.createWriteStream(path);
@@ -200,16 +223,8 @@
 
         // pngquant changes the process from `convert < pixmap > fileStream`
         // to `convert < pixmap | pngquant > fileStream`
-        if (settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8) {
-            var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
-
-            pngquantProc.on("error", function (err) { onStreamError("Error with pngquant: " + err); });
-            pngquantProc.stdin.on("error",  function (err) { onStreamError("Error with pngquant's STDIN: "  + err); });
-            pngquantProc.stdout.on("error", function (err) { onStreamError("Error with pngquant's STDOUT: " + err); });
-            pngquantProc.stderr.on("error", function (err) { onStreamError("Error with pngquant's STDERR: " + err); });
-
-            pngquantProc.stdout.pipe(fileStream);
-            convertProc.stdout.pipe(pngquantProc.stdin);
+        if (_shouldUsePNGQuant(settings)) {
+            _pipeThroughPNGQuant(binaryPaths, convertProc.stdout, fileStream, onStreamError);
         } else {
             // Pipe convert's output (the produced image) into the file stream
             convertProc.stdout.pipe(fileStream);

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -160,7 +160,6 @@
     }
 
     function _shouldUsePNGQuant(settings) {
-        return true;
         return settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8;
     }
 
@@ -177,20 +176,60 @@
     }
 
     // Exported functions
-    function savePixmap(binaryPaths, pixmap, path, settings) {
-        var fileCompleteDeferred = Q.defer(),
+    function streamPixmap(binaryPaths, pixmap, outputStream, settings, onStreamError) {
+        var outputCompleteDeferred = Q.defer(),
             fs  = require("fs");
 
         var args = _getConvertArguments(binaryPaths, pixmap, settings);
+
+        // Launch convert
+        var convertProc = spawn(binaryPaths.convert, args);
+
+        // Handle errors
+        convertProc.on("error", function (err) { onStreamError("Error with convert: " + err); });
+        convertProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
+        convertProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
+        convertProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
+        outputStream.on("error",  function (err) { onStreamError("Error with stream pixmap output stream: " + err); });
+
+        // Capture STDERR
+        var stderr = "";
+        convertProc.stderr.on("data", function (chunk) {
+            stderr += chunk;
+        });
+
+        // pngquant changes the process from `convert < pixmap > outputStream`
+        // to `convert < pixmap | pngquant > outputStream`
+        if (_shouldUsePNGQuant(settings)) {
+            _pipeThroughPNGQuant(binaryPaths, convertProc.stdout, outputStream, onStreamError);
+        } else {
+            // Pipe convert's output (the produced image) into the output stream
+            convertProc.stdout.pipe(outputStream);
+        }
+
+        // Send the pixmap to convert
+        convertProc.stdin.end(pixmap.pixels);
+
+        // Wait until convert is done (pipe from the last utility will close the stream)
+        outputStream.on("close", function () {
+            if (stderr) {
+                outputCompleteDeferred.reject("ImageMagick error: " + stderr);
+            } else {
+                outputCompleteDeferred.resolve();
+            }
+        });
+        
+        return outputCompleteDeferred.promise;
+    }
+
+    function savePixmap(binaryPaths, pixmap, path, settings) {
+        var fs  = require("fs");
 
         // Setup a file stream to the output file
         var fileStream = fs.createWriteStream(path);
         fileStream.on("error", function (err) {
             fileCompleteDeferred.reject("Could not create write stream for file " + path + ": " + err);
         });
-
-        // Launch convert
-        var convertProc = spawn(binaryPaths.convert, args);
 
         function onStreamError(err) {
             try {
@@ -207,42 +246,10 @@
             }
             fileCompleteDeferred.reject(err);
         }
-        
-        // Handle errors
-        convertProc.on("error", function (err) { onStreamError("Error with convert: " + err); });
-        convertProc.stdin.on("error",  function (err) { onStreamError("Error with convert's STDIN: "  + err); });
-        convertProc.stdout.on("error", function (err) { onStreamError("Error with convert's STDOUT: " + err); });
-        convertProc.stderr.on("error", function (err) { onStreamError("Error with convert's STDERR: " + err); });
-        fileStream.on("error",  function (err) { onStreamError("Error with stream to temporary file: " + err); });
 
-        // Capture STDERR
-        var stderr = "";
-        convertProc.stderr.on("data", function (chunk) {
-            stderr += chunk;
-        });
-
-        // pngquant changes the process from `convert < pixmap > fileStream`
-        // to `convert < pixmap | pngquant > fileStream`
-        if (_shouldUsePNGQuant(settings)) {
-            _pipeThroughPNGQuant(binaryPaths, convertProc.stdout, fileStream, onStreamError);
-        } else {
-            // Pipe convert's output (the produced image) into the file stream
-            convertProc.stdout.pipe(fileStream);
-        }
-
-        // Send the pixmap to convert
-        convertProc.stdin.end(pixmap.pixels);
-
-        // Wait until convert is done (pipe from the last utility will close the stream)
-        fileStream.on("close", function () {
-            if (stderr) {
-                fileCompleteDeferred.reject("ImageMagick error: " + stderr);
-            } else {
-                fileCompleteDeferred.resolve(path);
-            }
-        });
-        
-        return fileCompleteDeferred.promise;
+        // Stream the pixmap into the file and resolve with path when successful.
+        return streamPixmap(binaryPaths, pixmap, fileStream, settings, onStreamError)
+            .thenResolve(path);
     }
 
     exports.savePixmap = savePixmap;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -231,6 +231,7 @@
         return streamPixmap(binaryPaths, pixmap, fileStream, settings)
             .thenResolve(path)
             .catch(function(err) {
+                // If an error occurred, clean up the file.
                 try {
                     fileStream.close();
                 } catch (e) {
@@ -243,6 +244,9 @@
                 } catch (e) {
                     console.error("Error when deleting file", path, e);
                 }
+
+                // Propagate the error.
+                throw err;
             });
     }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1404,6 +1404,27 @@
         };
     };
 
+    Generator.prototype._parsePixmapProperties = function(pixmap) {
+        // ensure that arguments are of the correct type
+        pixmap.width          = parseInt(pixmap.width, 10);
+        pixmap.height         = parseInt(pixmap.height, 10);
+        pixmap.bitsPerChannel = parseInt(pixmap.bitsPerChannel, 10);
+    }
+
+    Generator.prototype._parsePixmapSaveSettings = function(settings) {
+        // ensure that arguments are of the correct type
+        if (settings._scale) {
+            settings._scale = parseFloat(settings._scale);
+        }
+
+        if (settings.hasOwnProperty("quality")) {
+            settings.quality  = parseInt(settings.quality, 10);
+        }
+        if (settings.hasOwnProperty("ppi")) {
+            settings.ppi      = parseFloat(settings.ppi);
+        }
+    }
+
     /**
      * @param {!Pixmap}  pixmap                An object representing the layer's image
      * @param {!integer} pixmap.width          The width of the image
@@ -1429,25 +1450,23 @@
      */
     Generator.prototype.savePixmap = function (pixmap, path, settings) {
         var convert = require("./convert");
-
-        if (settings._scale) {
-            settings._scale = parseFloat(settings._scale);
-        }
-
-        // check that arguments are of the correct type
-        pixmap.width          = parseInt(pixmap.width, 10);
-        pixmap.height         = parseInt(pixmap.height, 10);
-        pixmap.bitsPerChannel = parseInt(pixmap.bitsPerChannel, 10);
-        if (settings.hasOwnProperty("quality")) {
-            settings.quality  = parseInt(settings.quality, 10);
-        }
-        if (settings.hasOwnProperty("ppi")) {
-            settings.ppi      = parseFloat(settings.ppi);
-        }
-
+        this._parsePixmapProperties(pixmap);
+        this._parsePixmapSaveSettings(settings);
         return convert.savePixmap(this._paths, pixmap, path, settings);
     };
-    
+
+    /**
+     * @param {!Pixmap}  pixmap                An object representing the layer's image. See savePixmap for details.
+     * @param {!Stream}  outputStream          A Stream object to receive the converted pixmap.
+     * @param {!Object}  settings              An object with settings for converting the image. See savePixmap for details.
+     * @outputStream
+     */
+    Generator.prototype.streamPixmap = function(pixmap, outputStream, settings) {
+        var convert = require("./convert");
+        this._parsePixmapProperties(pixmap);
+        this._parsePixmapSaveSettings(settings);
+        return convert.streamPixmap(this._paths, pixmap, outputStream, settings);
+    }
 
     /**
      * Get an SVG representing the layer. Returns a promise that resolves to an SVG string.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1404,14 +1404,14 @@
         };
     };
 
-    Generator.prototype._parsePixmapProperties = function(pixmap) {
+    Generator.prototype._parsePixmapProperties = function (pixmap) {
         // ensure that arguments are of the correct type
         pixmap.width          = parseInt(pixmap.width, 10);
         pixmap.height         = parseInt(pixmap.height, 10);
         pixmap.bitsPerChannel = parseInt(pixmap.bitsPerChannel, 10);
-    }
+    };
 
-    Generator.prototype._parsePixmapSaveSettings = function(settings) {
+    Generator.prototype._parsePixmapSaveSettings = function (settings) {
         // ensure that arguments are of the correct type
         if (settings._scale) {
             settings._scale = parseFloat(settings._scale);
@@ -1423,7 +1423,7 @@
         if (settings.hasOwnProperty("ppi")) {
             settings.ppi      = parseFloat(settings.ppi);
         }
-    }
+    };
 
     /**
      * @param {!Pixmap}  pixmap                An object representing the layer's image
@@ -1456,17 +1456,17 @@
     };
 
     /**
-     * @param {!Pixmap}  pixmap                An object representing the layer's image. See savePixmap for details.
+     * @param {!Pixmap}  pixmap                An object representing the layer's image. See savePixmap.
      * @param {!Stream}  outputStream          A Stream object to receive the converted pixmap.
-     * @param {!Object}  settings              An object with settings for converting the image. See savePixmap for details.
+     * @param {!Object}  settings              An object with settings for converting the image. See savePixmap.
      * @outputStream
      */
-    Generator.prototype.streamPixmap = function(pixmap, outputStream, settings) {
+    Generator.prototype.streamPixmap = function (pixmap, outputStream, settings) {
         var convert = require("./convert");
         this._parsePixmapProperties(pixmap);
         this._parsePixmapSaveSettings(settings);
         return convert.streamPixmap(this._paths, pixmap, outputStream, settings);
-    }
+    };
 
     /**
      * Get an SVG representing the layer. Returns a promise that resolves to an SVG string.


### PR DESCRIPTION
I factored out a streamPixmap function in convert.js and exposed it via the generator API. The convert.savePixmap function is now implemented in terms of convert.streamPixmap.

streamPixmap gives API consumers like Crema more flexibility- for example, we can avoid hitting disk with preview images and stream them to the client.