### PR TITLE
account for sign when format extract args

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -125,7 +125,13 @@
                                 Number.isFinite(settings.extract.height) && settings.extract.height > 0) {
             finalWidth = settings.extract.width;
             finalHeight = settings.extract.height;
-            args.push("-extract", finalWidth + "x" + finalHeight + "+" + settings.extract.x + "+" + settings.extract.y);
+            var x = Number.isFinite(settings.extract.x) ? settings.extract.x : 0,
+                y = Number.isFinite(settings.extract.y) ? settings.extract.y : 0,
+                xSign = x < 0 ? "" : "+",
+                ySign = y < 0 ? "" : "+";
+            //extract offsets explictly need a sign. Negagtive x/y will include a "-" sign in toString
+            //and positive values will get an explicit "+" before them
+            args.push("-extract", finalWidth + "x" + finalHeight + xSign + x + ySign + y);
         }
 
         // Read the pixels in RGBA form from STDIN


### PR DESCRIPTION
When x/y were negative values, which are legal, we were getting the arguments was looking like ```100x100+-25+-25```. This fixes it to looks like ```100x100-25-25```