### PR TITLE
in some case, parsedValue is undefined(string type)

### DIFF
--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -541,6 +541,10 @@
                 try {
                     parsedValue = JSON.parse(parsedValue);
                 } catch (jsonParseException) {
+                    //in some case, parsedValue is undefined(string type), it will cause photoshop closed.
+                    if (parsedValue === 'undefined') {
+                        return;
+                    }
                     // do nothing; this is not unexpected
                 }
             }


### PR DESCRIPTION
in some case, parsedValue is undefined(string type), it will cause photoshop closed.