### PR TITLE
improve handling of effectsScaled

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1281,8 +1281,11 @@
                                     (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleY)),
 
             // Effects are not scaled when the transformation is non-uniform
-            effectsScaled       =
-                (paddedOutputWidthFloat / paddedInputWidth) === (paddedOutputHeightFloat / paddedInputHeight),
+            paddedFloatRatioDiff = Math.abs(paddedOutputWidthFloat / paddedInputWidth -
+                                            paddedOutputHeightFloat / paddedInputHeight),
+            floatDiffEpislon = 2e-16,
+            effectsScaled       = (targetWidth || targetHeight) ? paddedFloatRatioDiff < floatDiffEpislon :
+                                                                  targetScaleX === targetScaleY,
 
             paddedOutputWidth   = Math.ceil(paddedOutputWidthFloat),
             paddedOutputHeight  = Math.ceil(paddedOutputHeightFloat),
@@ -1392,9 +1395,9 @@
                         finalDelta = clipDelta * scale;
                     } else {
                         finalDelta = Math.min(staticDelta, clipDelta) * scale;
-                        clipDeltaTop = Math.max(0, clipDelta - staticDelta);
+                        clipDelta = Math.max(0, clipDelta - staticDelta);
                         finalDelta += Math.min(effectsDelta, clipDelta);
-                        clipDeltaTop = Math.max(0, clipDelta - staticDelta);
+                        clipDelta = Math.max(0, clipDelta - staticDelta);
                         finalDelta += Math.min(paddingDelta, clipDelta);
                     }
                     


### PR DESCRIPTION
We found a bug where effectsScaled was going to false when it should have been true. This was messing up some of the expected bounds calculations. The fix is if the scaling is just provided by ```targetScaleY``` and ```targetScaleX``` then compare those directly. If scale is done with a ```targetWidth``` or ```targetHeight``` then compare the difference to Number.EPSILON to allow for a little fudge factor in the float math. 

For this specific case it was:
```523.6 / 748 === 562.8 / 804``` which turned into ```0.700000000000001=== 0.7``` which was false.

This should also get merged into PS-16.0.0-release