### PR TITLE
Fixes if no options are passed to start issue

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -97,7 +97,8 @@
     Generator.prototype.start = function (options) {
         var self = this;
         
-        self._options = options || {};
+        options = options || {};
+        self._options = options;
         self._config = options.config || {};
         
         _logger.debug("Launching with config:\n%s", JSON.stringify(self._config, null, "  "));


### PR DESCRIPTION
Currently if no options are passed to `generator.start` then it will attempt to access `config` from an `undefined` options object.