### PR TITLE
Starting a websocket server will also register a domain if provided

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1868,13 +1868,17 @@
     /**
      * Start a Websocket server for use by the given plugin. A desired port may
      * be specified; if none is specified then the port is chosen dynamically.
+     *
+     * If a domain module is supplied, it will be used to register a domain after the server is started.
+     * @see DomainManager.loadDomainModule()
      * 
      * @param {!string} pluginId The ID of the plugin for which to start the server
      * @param {number=} desiredPort Optional desired port number for the server
+     * @param {Module=} domain Optional module with which to register a domain for this server
      * @return {Promise.<number>} Resolves with the actual port number on which
      *      the server is listening.
      */
-    Generator.prototype.startWebsocketServer = function (pluginId, desiredPort) {
+    Generator.prototype.startWebsocketServer = function (pluginId, desiredPort, domain) {
         var pluginConfig = this._plugins[PLUGIN_KEY_PREFIX + pluginId];
         if (!pluginConfig) {
             return Q.reject("Plugin not loaded: " + pluginId);
@@ -1887,6 +1891,14 @@
                     return this.updateCustomOption(pluginId, "websocketServerPort", actualPort)
                         .thenResolve(actualPort);
                 }.bind(this))
+                .then(function (actualPort) {
+                    if (domain) {
+                        return pluginConfig.websocketServer.registerDomain(domain)
+                            .thenResolve(actualPort);
+                    } else {
+                        return actualPort;
+                    }
+                })
                 .catch(function (err) {
                     return this.stopWebsocketServer(pluginId)
                         .thenReject(err);

--- a/lib/rpc/DomainManager.js
+++ b/lib/rpc/DomainManager.js
@@ -284,6 +284,20 @@
         }, this);
         return true; // if we fail, an exception will be thrown
     };
+
+    /**
+     * Loads and initializes a domain module "directly"
+     *
+     * @param {Module} domain A module that must contain an init(<DomainManager>) method
+     * @return {boolean} Whether loading succeded. (Failure will throw an exception).
+     */
+    DomainManager.prototype.loadDomainModule = function (domain) {
+        if (domain && domain.init && this._initializedDomainModules.indexOf(domain) < 0) {
+            domain.init(this, this._generator, this._logger);
+            this._initializedDomainModules.push(domain); // don't init more than once
+        }
+        return true; // if we fail, an exception will be thrown
+    };
     
     /**
      * Returns a description of all registered domains in the format of WebKit's

--- a/lib/rpc/Server.js
+++ b/lib/rpc/Server.js
@@ -231,5 +231,16 @@
         return deferred.promise;
     };
 
+    /**
+     * Register a domain within this server
+     *
+     * @param {Module} domain
+     * @return {Promise} Resolves when registration is complete
+     */
+    Server.prototype.registerDomain = function (domain) {
+        this._domainManager.loadDomainModule(domain);
+        return Q.resolve();
+    };
+
     module.exports = Server;
 }());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-core",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "photoshop-version": ">=15.0",
   "description": "Adobe Photoshop Generator Core",
   "main": "app.js",


### PR DESCRIPTION
To support generator-spaces plugin, add functionality to `generator.startWebsocketServer()` to register a domain.