### PR TITLE
Optional websocket origin validation

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1875,17 +1875,18 @@
      * @param {!string} pluginId The ID of the plugin for which to start the server
      * @param {number=} desiredPort Optional desired port number for the server
      * @param {Module=} domain Optional module with which to register a domain for this server
+     * @param {string=} origin Optional origin string used to verify websocket client connections
      * @return {Promise.<number>} Resolves with the actual port number on which
      *      the server is listening.
      */
-    Generator.prototype.startWebsocketServer = function (pluginId, desiredPort, domain) {
+    Generator.prototype.startWebsocketServer = function (pluginId, desiredPort, domain, origin) {
         var pluginConfig = this._plugins[PLUGIN_KEY_PREFIX + pluginId];
         if (!pluginConfig) {
             return Q.reject("Plugin not loaded: " + pluginId);
         }
 
         if (!pluginConfig.websocketServerPromise) {
-            pluginConfig.websocketServer = new Server(this, pluginConfig.logger);
+            pluginConfig.websocketServer = new Server(this, pluginConfig.logger, origin);
             pluginConfig.websocketServerPromise = pluginConfig.websocketServer.start(desiredPort)
                 .then(function (actualPort) {
                     return this.updateCustomOption(pluginId, "websocketServerPort", actualPort)

--- a/lib/rpc/Server.js
+++ b/lib/rpc/Server.js
@@ -44,12 +44,17 @@
      *
      * Server inherits from the EventEmitter class and exports itself
      * as the module.
+     *
+     * @param {Generator} generator
+     * @param {Logger} logger
+     * @param {string=} origin Optional origin string used to verify websocket client connections
      */
-    var Server = function (generator, logger) {
+    var Server = function (generator, logger, origin) {
         events.EventEmitter.call(this);
 
         this._generator = generator;
         this._logger = logger;
+        this._origin = origin;
 
         this._connectionManager = new ConnectionManager(logger);
         this._domainManager = new DomainManager(this._generator, this._logger, this._connectionManager);
@@ -137,7 +142,17 @@
                     this.stop();
                 }.bind(this));
                 
-                wsServer = new WebSocket.Server({server: httpServer});
+                var wsOptions = {
+                    server: httpServer
+                };
+
+                // Verify that the request's Origin header matches the specified origin
+                if (this._origin) {
+                    wsOptions.verifyClient = function (info) {
+                        return info.origin === this._origin;
+                    }.bind(this);
+                }
+                wsServer = new WebSocket.Server(wsOptions);
 
                 wsServer.on("error", function () {
                     this._logger.error(


### PR DESCRIPTION
This adds an optional parameter to `generator.startWebsocketServer()` which will validate the origin of websocket connections.  Immediately, this is useful for the generator-spaces plugin (used by Design Space) which can restrict connections from origin = `file://`

Can you please review @chrisbank ?