### PR TITLE
support for flite to perform image encoding

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -50,7 +50,7 @@
             // lose their transparency, making the colors too intense
             args.push("-background", BACKGROUND_COLOR_FOR_FLATTENING, "-flatten");
         }
-        if (format === "gif") {
+        if (format === "gif" && !_shouldUseFlite(settings, binaryPaths)) {
             // Make it so that pixels that were <1% transparent before become fully transparent
             // while the other pixels have the same color as if seen against a white background
             // Create a copy of the original image, making it truly RGBA, and delete the ARGB original
@@ -186,6 +186,10 @@
     function _shouldUsePNGQuant(settings) {
         return settings.usePngquant && settings.format === "png" && settings.pngquantQuality === 8;
     }
+    
+    function _shouldUseFlite(settings, binaryPaths) {
+        return settings.useFlite && binaryPaths.flite;
+    }
 
     function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, outputCompleteDeferred) {
         var pngquantProc = spawn(binaryPaths.pngquant, ["-"]);
@@ -203,7 +207,9 @@
         var args = _getConvertArguments(binaryPaths, pixmap, settings);
 
         // Launch convert
-        var convertProc = spawn(binaryPaths.convert, args);
+        var convertProc = (_shouldUseFlite(settings, binaryPaths) ?
+                           spawn(binaryPaths.flite, args) :
+                           spawn(binaryPaths.convert, args));
 
         // Handle errors
         _rejectDeferredOnProcessIOError(convertProc, "convert", outputCompleteDeferred);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -34,6 +34,7 @@
     var EventEmitter = require("events").EventEmitter,
         Q = require("q"),
         photoshop = require("./photoshop"),
+        convert = require("./convert"),
         util = require("util"),
         semver = require("semver"),
         xpm = require("./xpm"),
@@ -109,7 +110,7 @@
 
         function connectToPhotoshop() {
             var connectionDeferred = Q.defer();
-            self._photoshop = photoshop.createClient(options);
+            self._photoshop = photoshop.createClient(options, undefined, _logger);
             self._photoshop.once("connect", function () {
                 connectionDeferred.resolve(self);
             });
@@ -194,8 +195,24 @@
                                 err);
                             self._paths.pngquant = null;
                         });
+                
+                    var flitePath = process.platform === "darwin" ?
+                        resolve(psPath, "flitetranscoder") :
+                        resolve(psPath, "flitetranscoder.exe");
 
-                    return Q.all([convertPromise, pngquantPromise]);
+                    var flitePromise = Q.nfcall(fs.stat, flitePath)
+                        .then(function () {
+                            self._paths.flite = flitePath;
+                        })
+                        .fail(function (err) {
+                            _logger.warning("flitetranscoder binary is missing." +
+                                            " flite functionality will not be available.",
+                                err);
+                            self._paths.flite = null;
+                        });
+
+
+                    return Q.all([convertPromise, pngquantPromise, flitePromise]);
                 });
         }
 
@@ -964,6 +981,7 @@
                 scaleY:     settings.scaleY || 1,
                 bounds:     true,
                 boundsOnly: settings.boundsOnly,
+                settings: settings.thread,
                 useSmartScaling: settings.useSmartScaling || false,
                 includeAncestorMasks: settings.includeAncestorMasks || false,
                 convertToWorkingRGBProfile: settings.convertToWorkingRGBProfile || false,
@@ -1515,16 +1533,15 @@
      *    (This API should be considered private and may be removed at any time with only a bump to the "patch"
      *    version number of generator-core. Use at your own risk.)
      * @param {?boolean=} settings.usePngquant  If true, quantize 8-bit pngs using pngquant instead of convert
+     * @param {?boolean=} settings.useFlite  If true, use flite to for image encoding instead of convert
      * @return {Promise.<String>} Promise that resolves to the path of the file after write is complete and the
      *    file stream is closed
      */
     Generator.prototype.savePixmap = function (pixmap, path, settings) {
-        var convert = require("./convert");
-
         this._parsePixmapProperties(pixmap);
         this._parsePixmapSaveSettings(settings);
 
-        return convert.savePixmap(this._paths, pixmap, path, settings);
+        return convert.savePixmap(this._paths, pixmap, path, settings, _logger);
     };
 
     /**
@@ -1534,10 +1551,9 @@
      * @return {Promise} Promise that resolves (with an empty value) after outputStream is closed.
      */
     Generator.prototype.streamPixmap = function (pixmap, outputStream, settings) {
-        var convert = require("./convert");
         this._parsePixmapProperties(pixmap);
         this._parsePixmapSaveSettings(settings);
-        return convert.streamPixmap(this._paths, pixmap, outputStream, settings);
+        return convert.streamPixmap(this._paths, pixmap, outputStream, settings, _logger);
     };
 
     /**

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -224,5 +224,9 @@ if (params.boundsOnly) {
     actionDescriptor.putBoolean(stringIDToTypeID("boundsOnly"), params.boundsOnly);
 }
 actionDescriptor.putBoolean(stringIDToTypeID("bounds"), params.bounds);
+//needs to be set explicitly as a boolean
+if (params.thread === true || params.thread === false) {
+    actionDescriptor.putBoolean(stringIDToTypeID("thread"), params.thread);
+}
 
 executeAction(stringIDToTypeID("sendLayerThumbnailToNetworkClient"), actionDescriptor, DialogModes.NO);

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -134,18 +134,19 @@
         return new Logger(this, source);
     };
 
-    function makeLogMethod(level) {
+    function makeLogMethod(level, stackEntry) {
         return function () { // (message, arg1, ...)
             var message = arguments[0] || "",
                 args = Array.prototype.slice.call(arguments, 1),
                 callLocation = null,
-                time = null;
+                time = null,
+                entry = stackEntry === undefined ? 1 : stackEntry;
 
             if (!this.manager.ended &&
                 this.manager.level >= level &&
                 EventEmitter.listenerCount(this.manager, "message") > 0) {
                 
-                callLocation = getCallLocationFromStackString((new Error()).stack, 1);
+                callLocation = getCallLocationFromStackString((new Error()).stack, entry);
                 time = new Date();
 
                 this.manager.emit("message", {
@@ -157,6 +158,31 @@
                     args : args
                 });
             }
+        };
+    }
+    
+    function makeTimerStartMethod() {
+        return function (timerName) {
+            if (!timerName) {
+                return;
+            }
+            var startDate = new Date();
+            this._timerData[timerName] = startDate;
+            
+            this._timeLog(timerName + ": timer started");
+        };
+    }
+    
+    function makeTimerEndMethod() {
+        return function (timerName) {
+            if (!timerName || !this._timerData[timerName]) {
+                return;
+            }
+            var startDate = this._timerData[timerName],
+                endDate = new Date(),
+                duration = endDate.getTime() - startDate.getTime();
+            this._timeLog(timerName + ": " + duration + "ms");
+            this._timerData[timerName] = null;
         };
     }
 
@@ -176,6 +202,11 @@
                 value : source,
                 writable : false,
                 enumerable : true
+            },
+            "_timerData" : {
+                value : {},
+                writable : false,
+                enumerable : false
             }
         });
     }
@@ -184,12 +215,15 @@
      * Variadic logging methods. The first argument is the log message, and any additional
      * arguments are passed along in the "args" array in the log event.
      */
-    Logger.prototype.debug   = makeLogMethod(exports.LOG_LEVEL_DEBUG);
-    Logger.prototype.info    = makeLogMethod(exports.LOG_LEVEL_INFO);
-    Logger.prototype.warn    = makeLogMethod(exports.LOG_LEVEL_WARNING);
-    Logger.prototype.error   = makeLogMethod(exports.LOG_LEVEL_ERROR);
-    Logger.prototype.warning = Logger.prototype.warn;
-    Logger.prototype.log     = Logger.prototype.info;
+    Logger.prototype.debug    = makeLogMethod(exports.LOG_LEVEL_DEBUG);
+    Logger.prototype.info     = makeLogMethod(exports.LOG_LEVEL_INFO);
+    Logger.prototype.warn     = makeLogMethod(exports.LOG_LEVEL_WARNING);
+    Logger.prototype.error    = makeLogMethod(exports.LOG_LEVEL_ERROR);
+    Logger.prototype.warning  = Logger.prototype.warn;
+    Logger.prototype.log      = Logger.prototype.info;
+    Logger.prototype.time     = makeTimerStartMethod();
+    Logger.prototype.timeEnd  = makeTimerEndMethod();
+    Logger.prototype._timeLog = makeLogMethod(exports.LOG_LEVEL_INFO, 2);
 
 
     function levelToString(level) {

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -99,11 +99,11 @@
      * 
      * @constructor
      */
-    function PhotoshopClient(options, connectListener) {
+    function PhotoshopClient(options, connectListener, logger) {
         var self = this;
         
-        if (!self instanceof PhotoshopClient) {
-            return new PhotoshopClient(options, connectListener);
+        if (!(self instanceof PhotoshopClient)) {
+            return new PhotoshopClient(options, connectListener, logger);
         } else {
             var password = DEFAULT_PASSWORD;
             
@@ -113,6 +113,7 @@
             if (options.hasOwnProperty("inputFd")) { self._inputFd = options.inputFd; }
             if (options.hasOwnProperty("outputFd")) { self._outputFd = options.outputFd; }
             
+            self._logger = logger;
             self._receiveBuffer = new Buffer(INITIAL_MESSAGE_BUFFER_SIZE);
             self._receivedBytes = 0;
             self._writeQueue = [];
@@ -470,7 +471,7 @@
         if (duration > 10) {
             var size  = this._receivedBytes / 1024,
                 speed = size / (duration / 1000);
-            console.info(duration + "ms to receive " + round(size, 1) + " kB (" + round(speed, 1) + " kB/s)");
+            this._logger.info(duration + "ms to receive " + round(size, 1) + " kB (" + round(speed, 1) + " kB/s)");
         }
         
         // Extract the message
@@ -491,7 +492,7 @@
             bodyBuffer = this._crypto ? this._crypto.decipher(cipheredBody) : cipheredBody;
         duration = new Date().getTime() - startTime;
         if (duration > 10) {
-            console.info(duration + "ms to decrypt buffer");
+            this._logger.info(duration + "ms to decrypt buffer");
         }
 
         // Process message
@@ -562,8 +563,8 @@
     // Factory Functions
     // -----------------    
     
-    function createClient(options, connectListener) {
-        return new PhotoshopClient(options, connectListener);
+    function createClient(options, connectListener, logger) {
+        return new PhotoshopClient(options, connectListener, logger);
     }
 
     // Public Interface


### PR DESCRIPTION
This adds support for using the flitetranscoder instead of ImageMagic's convert or image encoding. This is enabled by adding the ```useFlite = true``` to the getPixmap settings object.