### PR TITLE
trim unexpected extra pixels from the result

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1312,8 +1312,8 @@
             paddedOutputWidth   = Math.round(paddedOutputWidthFloat),
             paddedOutputHeight  = Math.round(paddedOutputHeightFloat),
 
-            paddedOutputScaleX  = paddedOutputWidth  / paddedInputWidth,
-            paddedOutputScaleY  = paddedOutputHeight / paddedInputHeight,
+            paddedOutputScaleX  = paddedOutputWidthFloat  / paddedInputWidth,
+            paddedOutputScaleY  = paddedOutputHeightFloat / paddedInputHeight,
 
             // How much to scale everything that can be scaled (static + padding, maybe effects)
             scaleX              = effectsScaled ? paddedOutputScaleX : paddedOutputScaleX +
@@ -1324,16 +1324,16 @@
                                     (staticInputHeight + paddingInputHeight),
 
             // The expected size of the pixmap returned by Photoshop (does not include padding)
-            visibleOutputWidth  = Math.round(effectsScaled ? scaleX * visibleInputWidth :
-                                                        scaleX * staticInputWidth + effectsInputWidth),
-            visibleOutputHeight = Math.round(effectsScaled ? scaleY * visibleInputHeight :
-                                                        scaleY * staticInputHeight + effectsInputHeight);
+            visibleOutputWidth  = effectsScaled ? scaleX * visibleInputWidth :
+                                                        scaleX * staticInputWidth + effectsInputWidth,
+            visibleOutputHeight = effectsScaled ? scaleY * visibleInputHeight :
+                                                        scaleY * staticInputHeight + effectsInputHeight;
 
         // The settings for getPixmap
         return {
             // For backwards compatibility
-            expectedWidth:  visibleOutputWidth,
-            expectedHeight: visibleOutputHeight,
+            expectedWidth:  Math.round(visibleOutputWidth),
+            expectedHeight: Math.round(visibleOutputHeight),
             
             // For now: absolute scaling only
             inputRect: {
@@ -1390,11 +1390,22 @@
             },
             
             getExtractParamsForDocBounds: function (finalWidth, finalHeight) {
+                var unexpectedExtraWidth = Math.max(0, finalWidth - visibleOutputWidth),
+                    unexpectedExtraHeight = Math.max(0, finalHeight - visibleOutputHeight);
+                
                 //if the image and effects are completely contained there is nothing more to do
                 if (paddedInputBounds.top >= clipToBounds.top && paddedInputBounds.top <= clipToBounds.bottom &&
                     paddedInputBounds.left >= clipToBounds.left && paddedInputBounds.left <= clipToBounds.right &&
                     paddedInputBounds.right <= clipToBounds.right && paddedInputBounds.right >= clipToBounds.left &&
                     paddedInputBounds.bottom <= clipToBounds.bottom && paddedInputBounds.bottom >= clipToBounds.top) {
+                    if (unexpectedExtraHeight || unexpectedExtraWidth) {
+                        return {
+                            x:0,
+                            y:0,
+                            height: Math.round(unexpectedExtraHeight ? visibleOutputHeight : finalHeight),
+                            width: Math.round(unexpectedExtraWidth ? visibleOutputWidth : finalWidth)
+                        };
+                    }
                     return;
                 }
                 
@@ -1468,8 +1479,8 @@
                 return {
                     x: Math.round(deltaLeft),
                     y: Math.round(deltaTop),
-                    width: Math.round(finalWidth - deltaLeft - deltaRight),
-                    height: Math.round(finalHeight - deltaTop - deltaBottom)
+                    width: Math.max(0, Math.round(finalWidth - deltaLeft - deltaRight - unexpectedExtraWidth)),
+                    height: Math.max(0, Math.round(finalHeight - deltaTop - deltaBottom - unexpectedExtraHeight))
                 };
                 
             }


### PR DESCRIPTION
also don't round floats until as late as possible

This is for:
#4038819: (PS) Export As whole document or artboard: document with Fill Layer doesn't scale down correctly (objects are scaled but Fill layer doesn't scale, document is exported with original size)