### PR TITLE
don't allow negative numbers in padding val

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1382,10 +1382,10 @@
 
                 // Padding: how many transparent pixels to add on which side
                 return {
-                    left:   leftPadding,
-                    top:    topPadding,
-                    right:  missingWidth  - leftPadding,
-                    bottom: missingHeight - topPadding
+                    left:   Math.max(0, leftPadding),
+                    top:    Math.max(0, topPadding),
+                    right:  Math.max(0, missingWidth  - leftPadding),
+                    bottom: Math.max(0, missingHeight - topPadding)
                 };
             },
             


### PR DESCRIPTION
Fixes part of
#3981844 (PS or STI unknown) can't export asset after editing image size of Smart Object (was Size and clipping of document and layer is incorrect after editing image size of Smart Object layer)