### PR TITLE
domainManager.loadDomainModule should emit a 'newDomains' event

### DIFF
--- a/lib/rpc/DomainManager.js
+++ b/lib/rpc/DomainManager.js
@@ -292,9 +292,16 @@
      * @return {boolean} Whether loading succeded. (Failure will throw an exception).
      */
     DomainManager.prototype.loadDomainModule = function (domain) {
-        if (domain && domain.init && this._initializedDomainModules.indexOf(domain) < 0) {
+        // don't init more than once
+        var domainExists = this._initializedDomainModules.indexOf(domain) >= 0;
+
+        if (domain && domain.init && !domainExists) {
+            // initialize this domain and push it on to the list
             domain.init(this, this._generator, this._logger);
-            this._initializedDomainModules.push(domain); // don't init more than once
+            this._initializedDomainModules.push(domain);
+
+            // broadcast this new domain to clients
+            this.emitEvent("base", "newDomains");
         }
         return true; // if we fail, an exception will be thrown
     };


### PR DESCRIPTION
This event notifies clients that they should refresh the interface (fetch the latest domain definitions via HTTP call).  This is particularly important when handling plugin/generator restart scenarios.  

This affects only the newer domain registration process (used by generator-spaces plugin) where the domain is loaded during plugin startup (vis a vis the original process wherein clients register the domains externally).   

When the [NodeDomain/NodeConnection](https://github.com/adobe-photoshop/generator-connection) code attempts to handle a dropped connection, it polls the websocket until it becomes active and then tries to load the domain definitions.  However, there can be a small delay during plugin initialization between the time the websocket begins accepting connections, and when the domain is fully loaded.  See: https://github.com/adobe-photoshop/generator-core/blob/master/lib/generator.js#L1927

NodeDomain already attempts to account for this possible time gap by retrying a few times before giving up.  But for this to work reliably, the underlying NodeConnection must refetch the domain definitions via an HTTP call.  THIS PR forces that refetch by emitting the "newDomains" event.  Side note: This event emission already happens in the other (original) domain registration process, but was omitted in the implementation of the new domain registration process.

@iwehrman please take a look.
I cleaned the loadDomainModule function up a bit for clarity, but the only functional change is the new `.emitEvent()`