### PR TITLE
add support for new photoshop api to include icc profile data along w…

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -151,6 +151,10 @@
             // Set the canvas size and position the image inside of it
             args.push("-extent", finalWidth + "x" + finalHeight + "-" + padding.left + "-" + padding.top);
         }
+        
+        if (pixmap.iccProfile && _shouldUseFlite(settings, binaryPaths)) {
+            args.push("--profile-data-len", pixmap.iccProfile.length);
+        }
 
         // Define conversions
         args = args.concat(_getConvertArgumentsForSettings(settings, binaryPaths));
@@ -213,7 +217,7 @@
                            spawn(binaryPaths.convert, args));
         
         if (_shouldUseFlite(settings, binaryPaths)) {
-            logger.log("Using Flite for image encoding");
+            logger.log("Using Flite for image encoding" + (pixmap.iccProfile ? " with icc profile" : ""));
         }
 
         // Handle errors
@@ -234,6 +238,10 @@
             convertProc.stdout.pipe(outputStream);
         }
 
+        //send the iccProfile if present
+        if (pixmap.iccProfile && _shouldUseFlite(settings, binaryPaths)) {
+            convertProc.stdin.write(pixmap.iccProfile);
+        }
         // Send the pixmap to convert
         convertProc.stdin.end(pixmap.pixels);
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -152,6 +152,12 @@
                     self._messageDeferreds[messageID].notify({type: "pixmap", value: messageBody});
                 }
             });
+            
+            self._photoshop.on("iccProfile", function (messageID, messageBody) { // , rawMessage)
+                if (self._messageDeferreds[messageID]) {
+                    self._messageDeferreds[messageID].notify({type: "iccProfile", value: messageBody});
+                }
+            });
 
             return connectionDeferred.promise;
         }
@@ -261,8 +267,8 @@
     // to happen internally (via a "finally" handler that this method installs on the deferred).
     //
     // The progress notification will be an object of the form:
-    //    { type : [string like "javascript" or "pixmap"],
-    //      value : [dependent on type -- Object if "javascript", Buffer if "pixmap"] }
+    //    { type : [string like "javascript" or "pixmap" or "iccProfile"],
+    //      value : [dependent on type -- Object if "javascript", Buffer if "pixmap" or "iccProfile"] }
     //
     // If the caller of this message never resolves/rejects the returned deferred, then we'll have a
     // memory leak on our hands.
@@ -930,8 +936,10 @@
      *     before they are sent to generator. The color is converted to the working RGB profile (specified for
      *     the document in PS). By default (when this setting is false), the "raw" RGB data is sent, which is
      *     what is usually desired. (Default: false)
-     * @param {?boolean} settings.useICCProfile: String with the ICC color profile to use. If set this overrides
+     * @param {?string} settings.useICCProfile: String with the ICC color profile to use. If set this overrides
      *     the convertToWorkingRGBProfile flag. A common value is "sRGB IEC61966-2.1". (Default: "")
+     * @param {?boolean} settings.getICCProfileData: If true then the final ICC profile for the image is included 
+     *     along with the returned pixamp (added after PS 16.1)
      * @param {?boolean} settings.allowDither controls whether any dithering could possibly happen in the color
      *     conversion to 8-bit RGB. If false, then dithering will definitely not occur, regardless of either
      *     the value of useColorSettingsDither and the color settings in Photoshop. (Default: false)
@@ -969,7 +977,7 @@
             executionDeferred = null,
             jsDeferred        = Q.defer(),
             pixmapDeferred    = Q.defer(),
-            overallDeferred   = Q.defer(),
+            profileDeferred   = Q.defer(),
             params            = {
                 documentId: documentId,
                 layerSpec:  layerSpec,
@@ -986,6 +994,7 @@
                 includeAncestorMasks: settings.includeAncestorMasks || false,
                 convertToWorkingRGBProfile: settings.convertToWorkingRGBProfile || false,
                 useICCProfile: settings.useICCProfile || "",
+                getICCProfileData: settings.getICCProfileData || false,
                 allowDither: settings.allowDither || false,
                 useColorSettingsDither: settings.useColorSettingsDither || false,
                 interpolationType: settings.interpolationType,
@@ -1007,9 +1016,6 @@
         // The two deferreds at the top of this function (jsDeferred and pixmapDeferred) resolve when we've
         // received all of the expected messages of the respective type with the expected content. 
         //
-        // overallDeferred (the promise of which is returned by this function) resolves when both jsDeferred and
-        // pixmapDeferred resolve.
-        //
         // Note that this method could be slightly more efficient if we didn't create the pixmapDeffered in cases
         // where it wasn't necessary. But the logic is much simpler if we just create it and then resolve it
         // in cases where we don't need it. When the day comes that Generator is slow because we create one
@@ -1025,6 +1031,8 @@
                 }
             } else if (message.type === "pixmap") {
                 pixmapDeferred.resolve(message.value);
+            } else if (message.type === "iccProfile") {
+                profileDeferred.resolve(message.value);
             } else {
                 _logger.warn("Unexpected response from Photoshop:", message);
                 executionDeferred.reject("Unexpected response from Photoshop");
@@ -1034,37 +1042,44 @@
         executionDeferred.promise.fail(function (err) {
             jsDeferred.reject(err);
             pixmapDeferred.reject(err);
+            profileDeferred.reject(err);
         });
 
         // Resolve the pixmapDeferred now if we aren't actually expecting a pixmap
         if (params.boundsOnly) {
             pixmapDeferred.resolve();
+            profileDeferred.resolve();
+        }
+        
+        // Resolve the profileDefferred if we aren't expecting it to come back 
+        if (!params.getICCProfileData) {
+            profileDeferred.resolve();
         }
 
-        Q.all([jsDeferred.promise, pixmapDeferred.promise]).spread(
-            function (js, pixmapBuffer) {
+        return Q.all([jsDeferred.promise, profileDeferred.promise, pixmapDeferred.promise]).spread(
+            function (js, iccProfileBuffer, pixmapBuffer) {
                 executionDeferred.resolve();
 
                 if (params.boundsOnly && js && js.bounds) {
-                    overallDeferred.resolve(js);
+                    return js;
                 } else if (js && js.bounds && pixmapBuffer) {
                     var pixmap = xpm.Pixmap(pixmapBuffer);
                     pixmap.bounds = js.bounds;
-                    overallDeferred.resolve(pixmap);
+                    if (iccProfileBuffer) {
+                        pixmap.iccProfile = iccProfileBuffer;
+                    }
+                    return pixmap;
                 } else {
                     var errStr = "Unexpected response from PS in getLayerPixmap: jsDeferred val: " +
                         JSON.stringify(js) +
+                        ", iccProfileBuffer was expected: " + params.getICCProfileData + ", val: " +
+                        iccProfileBuffer ? "truthy" : "falsy" +
                         ", pixmapDeferred val: " +
                         pixmapBuffer ? "truthy" : "falsy";
-                    overallDeferred.reject(new Error(errStr));
+                    throw new Error(errStr);
                 }
-            }, function (err) {
-                executionDeferred.reject(err);
-                overallDeferred.reject(err);
             }
         );
-
-        return overallDeferred.promise;
     };
 
     /**

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -26,6 +26,8 @@
 //         what is usually desired. (Default: false)
 //   - useICCProfile: String with the ICC color profile to use. If set this overrides
 //         the convertToWorkingRGBProfile flag. A common value is "sRGB IEC61966-2.1". (Default: "")
+//   - getICCProfileData: If true then the final ICC profile for the image is included 
+//         along with the returned pixamp (added after PS 16.1)
 //   - allowDither: controls whether any dithering could possibly happen in the color conversion
 //         to 8-bit RGB. If false, then dithering will definitely not occur, regardless of either
 //         the value of useColorSettingsDither and the color settings in Photoshop. (Default: false)
@@ -207,6 +209,10 @@ if (params.hasOwnProperty("convertToWorkingRGBProfile")) {
 
 if (params.hasOwnProperty("useICCProfile")) {
     actionDescriptor.putString(stringIDToTypeID("useICCProfile"), String(params.useICCProfile));
+}
+
+if (params.hasOwnProperty("getICCProfileData")) {
+    actionDescriptor.putBoolean(stringIDToTypeID("sendThumbnailProfile"), !!params.getICCProfileData);
 }
 
 // NOTE: on the PS side, allowDither and useColorSettingsDither default to "true" if they are

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -65,6 +65,7 @@
         MESSAGE_TYPE_ERROR        = 1,
         MESSAGE_TYPE_JAVASCRIPT   = 2,
         MESSAGE_TYPE_PIXMAP       = 3,
+        MESSAGE_TYPE_ICC_PROFILE  = 4,
         MESSAGE_TYPE_KEEPALIVE    = 6,
         STATUS_NO_COMM_ERROR      = 0;
     
@@ -553,6 +554,8 @@
             }
         } else if (messageType === MESSAGE_TYPE_PIXMAP) {
             this.emit("pixmap", messageID, messageBody, rawMessage);
+        } else if (messageType === MESSAGE_TYPE_ICC_PROFILE) {
+            this.emit("iccProfile", messageID, messageBody, rawMessage);
         } else if (messageType === MESSAGE_TYPE_ERROR) {
             this.emit("error", { id: messageID, body: messageBody.toString("utf8") });
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-core",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "photoshop-version": ">=15.0",
   "description": "Adobe Photoshop Generator Core",
   "main": "app.js",


### PR DESCRIPTION
add support for new photoshop api to include icc profile data along with the pixmap data. This will be in a version of PS after the 16.1 release.

There are changes in Photoshop to provide the profile data and changes to flitetranscoder to consume the data.

Once all the generator core and genetate assets changes are in Irina will test the actual functionality. For now just make sure the code looks good and nothing accidentally breaks without those other pieces. 