### PR TITLE
Upgrade two dependencies due to known vulnerabilities

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,11 @@ module.exports = function (grunt) {
         
         nodeunit : {
             all : ["test/test-*.js"]
+        },
+
+        nsp: {
+            package: grunt.file.readJSON("package.json"),
+            shrinkwrap: grunt.file.readJSON("npm-shrinkwrap.json")
         }
 
     });
@@ -70,8 +75,9 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-jscs");
     grunt.loadNpmTasks("grunt-contrib-nodeunit");
+    grunt.loadNpmTasks("grunt-nsp");
 
-    grunt.registerTask("test", ["jshint", "jscs", "nodeunit"]);
+    grunt.registerTask("test", ["jshint", "jscs", "nodeunit", "nsp"]);
 
     grunt.registerTask("default", ["test"]);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,9 +25,9 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "semver": {
-      "version": "2.3.2",
-      "from": "semver@2.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+      "version": "5.1.0",
+      "from": "semver@latest",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "ws": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,35 +4,45 @@
   "dependencies": {
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@~0.6",
+      "from": "optimist@0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@~0.0.2"
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         },
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@~0.0.1"
+          "from": "minimist@0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
     },
     "q": {
       "version": "1.0.1",
-      "from": "q@~1.0"
+      "from": "q@1.0.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "semver": {
       "version": "2.3.2",
-      "from": "semver@~2.3"
+      "from": "semver@2.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
     },
     "ws": {
-      "version": "0.4.31",
-      "from": "ws@git+https://github.com/adobe-photoshop/ws.git#v0.4.31-no-native",
-      "resolved": "git+https://github.com/adobe-photoshop/ws.git#f89590b37ef8ba322636e8ef8187252c06eec143",
+      "version": "1.0.1",
+      "from": "ws@1.0.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
       "dependencies": {
         "options": {
-          "version": "0.0.5",
-          "from": "options@0.0.5",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
+          "version": "0.0.6",
+          "from": "options@>=0.0.5",
+          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+        },
+        "ultron": {
+          "version": "1.0.2",
+          "from": "ultron@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "optimist": "~0.6",
     "q": "~1.0",
-    "semver": "~2.3",
+    "semver": "^5.1.0",
     "ws": "^1.0.1"
   },
   "devDependencies": {
@@ -24,7 +24,8 @@
     "grunt-contrib-jshint": "~0.10",
     "grunt-contrib-nodeunit": "~0.3",
     "grunt-jscs": "~0.6.1",
-    "nodeunit": "~0.8",
-    "jscs-trailing-whitespace-in-source": "0.0.1"
+    "grunt-nsp": "^2.1.2",
+    "jscs-trailing-whitespace-in-source": "0.0.1",
+    "nodeunit": "~0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "optimist": "~0.6",
     "q": "~1.0",
     "semver": "~2.3",
-    "ws": "git+https://github.com/adobe-photoshop/ws.git#v0.4.31-no-native"
+    "ws": "^1.0.1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Upgrade `ws` and `semver` to avoid two known vulnerabilities.  Also added a new grunt task `nsp` which checks the dependencies against a list of known vulnerabilities.

Note that we previously used a custom/forked version of `ws` which stripped it of some binary sub-dependencies.  The newest version provides those binaries (performance optimizations) as "opt in" modules.  So, now we can just use the stock version!

cc @iwehrman @pineapplespatula 