### PR TITLE
switch to using width and height variables instead of always using bounds

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -920,14 +920,18 @@
      * @param {?Object}  settings.outputRect Rectangle into which the the layer should fit
      * @param {?float}   settings.scaleX     The factor by which to scale the image horizontally (1.0 for 100%)
      * @param {?float}   settings.scaleX     The factor by which to scale the image vertically (1.0 for 100%)
-     * @param {!float}   settings.inputRect.left    Pixel distance of the rect's left side from the doc's left side
-     * @param {!float}   settings.inputRect.top     Pixel distance of the rect's top from the doc's top
-     * @param {!float}   settings.inputRect.right   Pixel distance of the rect's right side from the doc's left side
-     * @param {!float}   settings.inputRect.bottom  Pixel distance of the rect's bottom from the doc's top
-     * @param {!float}   settings.outputRect.left   Pixel distance of the rect's left side from the doc's left side
-     * @param {!float}   settings.outputRect.top    Pixel distance of the rect's top from the doc's top
-     * @param {!float}   settings.outputRect.right  Pixel distance of the rect's right side from the doc's left side
-     * @param {!float}   settings.outputRect.bottom Pixel distance of the rect's bottom from the doc's top
+     * @param {float=}   settings.inputRect.left    Pixel distance of the rect's left side from the doc's left side
+     * @param {float=}   settings.inputRect.top     Pixel distance of the rect's top from the doc's top
+     * @param {float=}   settings.inputRect.right   Pixel distance of the rect's right side from the doc's left side
+     * @param {float=}   settings.inputRect.bottom  Pixel distance of the rect's bottom from the doc's top
+     * @param {float=}   settings.outputRect.left   Pixel distance of the rect's left side from the doc's left side
+     * @param {float=}   settings.outputRect.top    Pixel distance of the rect's top from the doc's top
+     * @param {float=}   settings.outputRect.right  Pixel distance of the rect's right side from the doc's left side
+     * @param {float=}   settings.outputRect.bottom Pixel distance of the rect's bottom from the doc's top
+     * @param {float=}   settings.ClipBounds.left   Pixel distance of the rect's left side from the layers's left side
+     * @param {float=}   settings.ClipBounds.top    Pixel distance of the rect's top from the layers's top
+     * @param {float=}   settings.ClipBounds.right  Pixel distance of the rect's right side from the layers's left side
+     * @param {float=}   settings.ClipBounds.bottom Pixel distance of the rect's bottom from the layers's top
      * @param {?string} settings.useJPGEncoding Use aternamte huffman encoding, either optimal, or precomputed
      * @param {?boolean} settings.useSmartScaling Use Photoshop's "smart" scaling to scale layer, which
      *     (confusingly) means that stroke effects (e.g. rounded rect corners) are *not* scaled. (Default: false)
@@ -1002,7 +1006,8 @@
                 interpolationType: settings.interpolationType,
                 forceSmartPSDPixelScaling: settings.forceSmartPSDPixelScaling || false,
                 clipToDocumentBounds: settings.clipToDocumentBounds || false,
-                maxDimension: settings.maxDimension || 10000
+                maxDimension: settings.maxDimension || 10000,
+                clipBounds: settings.clipBounds
             };
 
         // Because of PS communication irregularities in different versions of PS, it's very complicated to
@@ -1297,9 +1302,30 @@
             targetHeight        = settings.height,
             targetScaleX        = settings.scaleX || settings.scale || 1,
             targetScaleY        = settings.scaleY || settings.scale || 1,
-            
-            // Width and height of the bounds
-            staticInputWidth    = staticInputBounds.right   - staticInputBounds.left,
+            clippedWidth        = Math.min(paddedInputBounds.right, clipToBounds.right) -
+                                    Math.max(paddedInputBounds.left, clipToBounds.left),
+            clippedHeight       = Math.min(paddedInputBounds.bottom, clipToBounds.bottom) -
+                                    Math.max(paddedInputBounds.top, clipToBounds.top),
+            clippedTop          = Math.max(0, paddedInputBounds.top),
+            clippedLeft         = Math.max(0, paddedInputBounds.left),
+            outputRect,
+            inputRect,
+            clipBounds;
+
+        if (clippedLeft !== paddedInputBounds.left ||
+            clippedTop !== paddedInputBounds.top ||
+            (clippedLeft + clippedWidth) !== paddedInputBounds.right ||
+            (clippedTop + clippedHeight) !== paddedInputBounds.bottom) {
+            clipBounds = {
+                left: clippedLeft,
+                top: clippedTop,
+                right: clippedLeft + clippedWidth,
+                bottom: clippedTop + clippedHeight
+            };
+        }
+    
+        // Width and height of the bounds
+        var staticInputWidth    = staticInputBounds.right   - staticInputBounds.left,
             staticInputHeight   = staticInputBounds.bottom  - staticInputBounds.top,
             visibleInputWidth   = visibleInputBounds.right  - visibleInputBounds.left,
             visibleInputHeight  = visibleInputBounds.bottom - visibleInputBounds.top,
@@ -1346,27 +1372,34 @@
             visibleOutputHeight = effectsScaled ? scaleY * visibleInputHeight :
                                                         scaleY * staticInputHeight + effectsInputHeight;
 
-        // The settings for getPixmap
-        return {
-            // For backwards compatibility
-            expectedWidth:  Math.round(visibleOutputWidth),
-            expectedHeight: Math.round(visibleOutputHeight),
-            
-            // For now: absolute scaling only
-            inputRect: {
+
+        if (targetWidth || targetHeight) {
+            inputRect = {
                 left:   staticInputBounds.left,
                 top:    staticInputBounds.top,
                 right:  staticInputBounds.left + staticInputWidth,
                 bottom: staticInputBounds.top  + staticInputHeight
-            },
-            outputRect: {
+            };
+            outputRect = {
                 left:   0,
                 top:    0,
                 right:  Math.round(
                             visibleOutputWidth  - effectsInputWidth  * (effectsScaled ? scaleX : 1)),
                 bottom: Math.round(
                             visibleOutputHeight - effectsInputHeight * (effectsScaled ? scaleY : 1))
-            },
+            };
+        }
+
+        // The settings for getPixmap
+        return {
+            
+            inputRect: inputRect,
+            outputRect: outputRect,
+
+            scaleX: targetScaleX,
+            scaleY: targetScaleY,
+
+            clipBounds: clipBounds,
             
             // The padding depends on the actual size of the returned image, therefore provide a function
             getPadding: function (pixmapWidth, pixmapHeight) {

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -49,6 +49,7 @@
 //         Note that this option *cannot* be used with an inputRect/outputRect scaling. If inputRect/outputRect
 //         is set, this setting will be ignored and the pixels will not be cropped to document bounds.
 //         (Default: false)
+//   - clipBounds: if present crops retuned pixels to the given bounds
 //   - compId: number, layer comp ID (optionally and exclusive of compIndex)
 //   - compIndex: number, layer comp index (optionally and exclusive of compId) 
 //   - maxDimension: number, maximal dimension of pixmap in pixels
@@ -103,8 +104,8 @@ if (params.inputRect && params.outputRect) {
         transform.putBoolean(stringIDToTypeID("forceDumbScaling"), true);
     }
 
-    transform.putDouble(stringIDToTypeID("width"), params.scaleX * 100);
-    transform.putDouble(stringIDToTypeID("height"), params.scaleY * 100);
+    transform.putDouble(charIDToTypeID("Wdth"), params.scaleX * 100);
+    transform.putDouble(charIDToTypeID("Hght"), params.scaleY * 100);
 }
 
 if (transform) {
@@ -224,6 +225,21 @@ actionDescriptor.putBoolean(stringIDToTypeID("useColorSettingsDither"), !!params
 
 if (params.hasOwnProperty("clipToDocumentBounds")) {
     actionDescriptor.putBoolean(stringIDToTypeID("clipToDocumentBounds"), !!params.clipToDocumentBounds);
+}
+
+if (params.clipBounds) {
+
+    // The part of the document to use
+    var clipBounds = params.clipBounds,
+        psClipRect = new ActionDescriptor();
+
+    psClipRect.putUnitDouble(stringIDToTypeID("left"), charIDToTypeID("#Pxl"), clipBounds.left);
+    psClipRect.putUnitDouble(stringIDToTypeID("top"), charIDToTypeID("#Pxl"), clipBounds.top);
+    
+    psClipRect.putUnitDouble(stringIDToTypeID("right"), charIDToTypeID("#Pxl"), clipBounds.right);
+    psClipRect.putUnitDouble(stringIDToTypeID("bottom"), charIDToTypeID("#Pxl"), clipBounds.bottom);
+
+    actionDescriptor.putObject(stringIDToTypeID("clipBounds"), stringIDToTypeID("clipBounds"), psClipRect);
 }
 
 if (params.boundsOnly) {


### PR DESCRIPTION
Previously Generator always sent PS a set of bounds to define the scale factor that was desired. In most cases this produced extra (sometimes erroneous) scaling. Letting PS scale directly from the user supplied scale factors produces more consistent results. 

requires https://github.com/adobe-photoshop/generator-assets-automation/pull/27

This CL also introduces the use of a bounds clipping path that uses Photoshop's API to clip images to bounds, instead of image magick (or flite). In the future this will hopefully allow us to remove some of our bounds management and rely on PS for clipping. 