### PR TITLE
Modify getExtractParamsForDocBounds to be tolerant of artboards that include background color

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1407,8 +1407,10 @@
             },
             
             getExtractParamsForDocBounds: function (finalWidth, finalHeight) {
-                var unexpectedExtraWidth = Math.max(0, finalWidth - visibleOutputWidth),
-                    unexpectedExtraHeight = Math.max(0, finalHeight - visibleOutputHeight);
+                var outputWidth = Math.max(paddedOutputWidth, visibleOutputWidth),
+                    outputHeight = Math.max(paddedOutputHeight, visibleOutputHeight),
+                    unexpectedExtraWidth = Math.max(0, finalWidth - outputWidth),
+                    unexpectedExtraHeight = Math.max(0, finalHeight - outputHeight);
                 
                 //if the image and effects are completely contained there is nothing more to do
                 if (paddedInputBounds.top >= clipToBounds.top && paddedInputBounds.top <= clipToBounds.bottom &&


### PR DESCRIPTION
A new PS artboard feature allows custom artboard background colors to be included in the exported "thumbnail" that PS provides to generator.  This PR fixes a generator bug that clips the image to the "visible bounds" of the layers within an artboard *IF* the PS thumbnail contains the full artboard bounds.  This bug/code-path does not seem to exist today, because the PS thumbnail alwyas includes only the aforementioned visible bounds and generator then correctly pads accordingly.

I think this falls into the "lipstick on a pig" category by patching up the overly-complex (poorly understood) "approximate bounds" code path.  But, it seems safe, and passes all appropriate automation tests.

Note: This PR can currently be fully tested only on the cyan branch of photoshop.