### PR TITLE
take clipping into account when determining scale factors

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1339,31 +1339,33 @@
             paddingInputWidth   = paddedInputWidth  - visibleInputWidth,
             paddingInputHeight  = paddedInputHeight - visibleInputHeight,
 
+            finalInputWidth = paddingInputWidth ? paddedInputWidth : clippedWidth,
+            finalInputHeight = paddingInputHeight ? paddedInputHeight : clippedHeight,
             // Designated image size
-            paddedOutputWidthFloat = targetWidth  || (paddedInputWidth *
-                                    (targetHeight  ? (targetHeight  / paddedInputHeight) : targetScaleX)),
-            paddedOutputHeightFloat = targetHeight || (paddedInputHeight *
-                                    (targetWidth ? (targetWidth / paddedInputWidth) : targetScaleY)),
+            finalOutputWidthFloat = targetWidth  || (finalInputWidth *
+                                    (targetHeight  ? (targetHeight  / finalInputHeight) : targetScaleX)),
+            finalOutputHeightFloat = targetHeight || (finalInputHeight *
+                                    (targetWidth ? (targetWidth / finalInputWidth) : targetScaleY)),
 
             // Effects are not scaled when the transformation is non-uniform
-            paddedFloatRatioDiff = Math.abs(paddedOutputWidthFloat / paddedInputWidth -
-                                            paddedOutputHeightFloat / paddedInputHeight),
+            finalFloatRatioDiff = Math.abs(finalOutputWidthFloat / finalInputWidth -
+                                            finalOutputHeightFloat / finalInputHeight),
             floatDiffEpislon = 2e-16,
-            effectsScaled       = (targetWidth || targetHeight) ? paddedFloatRatioDiff < floatDiffEpislon :
+            effectsScaled       = (targetWidth || targetHeight) ? finalFloatRatioDiff < floatDiffEpislon :
                                                                   targetScaleX === targetScaleY,
 
-            paddedOutputWidth   = Math.round(paddedOutputWidthFloat),
-            paddedOutputHeight  = Math.round(paddedOutputHeightFloat),
+            finalOutputWidth   = Math.round(finalOutputWidthFloat),
+            finalOutputHeight  = Math.round(finalOutputHeightFloat),
 
-            paddedOutputScaleX  = paddedOutputWidthFloat  / paddedInputWidth,
-            paddedOutputScaleY  = paddedOutputHeightFloat / paddedInputHeight,
+            finalOutputScaleX  = finalOutputWidthFloat  / finalInputWidth,
+            finalOutputScaleY  = finalOutputHeightFloat / finalInputHeight,
 
             // How much to scale everything that can be scaled (static + padding, maybe effects)
-            scaleX              = effectsScaled ? paddedOutputScaleX : paddedOutputScaleX +
-                                    (effectsInputWidth  * (paddedOutputScaleX - 1)) /
+            scaleX              = effectsScaled ? finalOutputScaleX : finalOutputScaleX +
+                                    (effectsInputWidth  * (finalOutputScaleX - 1)) /
                                     (staticInputWidth  + paddingInputWidth),
-            scaleY              = effectsScaled ? paddedOutputScaleY : paddedOutputScaleY +
-                                    (effectsInputHeight * (paddedOutputScaleY - 1)) /
+            scaleY              = effectsScaled ? finalOutputScaleY : finalOutputScaleY +
+                                    (effectsInputHeight * (finalOutputScaleY - 1)) /
                                     (staticInputHeight + paddingInputHeight),
 
             // The expected size of the pixmap returned by Photoshop (does not include padding)
@@ -1419,8 +1421,8 @@
                 }
 
                 var // How much padding is necessary in both dimensions
-                    missingWidth  = paddedOutputWidth  - pixmapWidth,
-                    missingHeight = paddedOutputHeight - pixmapHeight,
+                    missingWidth  = finalOutputWidth  - pixmapWidth,
+                    missingHeight = finalOutputHeight - pixmapHeight,
                     // How of the original padding was on which side (default 0)
                     leftRatio     = paddingInputWidth === 0 ? 0 :
                         ((visibleInputBounds.left - paddedInputBounds.left) / paddingInputWidth),
@@ -1440,8 +1442,8 @@
             },
             
             getExtractParamsForDocBounds: function (finalWidth, finalHeight) {
-                var outputWidth = Math.max(paddedOutputWidth, visibleOutputWidth),
-                    outputHeight = Math.max(paddedOutputHeight, visibleOutputHeight),
+                var outputWidth = Math.max(finalOutputWidth, visibleOutputWidth),
+                    outputHeight = Math.max(finalOutputHeight, visibleOutputHeight),
                     unexpectedExtraWidth = Math.max(0, finalWidth - outputWidth),
                     unexpectedExtraHeight = Math.max(0, finalHeight - outputHeight);
                 
@@ -1475,7 +1477,7 @@
                     clipDeltaLeft = Math.abs(Math.min(0, paddedInputBounds.left - clipToBounds.left)),
                     clipDeltaRight = Math.abs(Math.min(0, clipToBounds.right - paddedInputBounds.right)),
                     clipDeltaBottom = Math.abs(Math.min(0, clipToBounds.bottom - paddedInputBounds.bottom));
-                
+             
                 var calcScaledDelta = function (clipDelta, staticDelta, effectsDelta, paddingDelta, scale) {
                     var finalDelta = 0;
                     if (effectsScaled) {


### PR DESCRIPTION
@mcilroyc  can you take a look at this. I'm still not happy with this function. and I feel like it does a lot of extra work, but I'm certain it shouldn't be ignoring the clipped case when determining scaleX and scaleY