### PR TITLE
Very minor log improvements

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1803,7 +1803,7 @@
 
         // Do the actual plugin load
         try {
-            _logger.debug("Loading plugin: %s", metadata.name);
+            _logger.debug("Loading plugin: %s (v%s) from directory: %s", metadata.name, metadata.version, directory);
             // NOTE: We don't need to worry about accidentally requiring the same plugin twice.
             // If the user did try to load it twice, require's caching would return the same
             // package.json both times (even if the package.json changed on disk), and so

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -215,7 +215,7 @@
             });
             
             self._readStream.on("error", function (err) {
-                self.emit("error", "Pipe error: " + err);
+                self.emit("error", "Pipe read error: " + err);
                 self.disconnect();
             });
                     
@@ -235,7 +235,7 @@
             }
 
             self._writeStream.on("error", function (err) {
-                self.emit("error", "Pipe error: " + err);
+                self.emit("error", "Pipe write error: " + err);
                 self.disconnect();
             });
                     
@@ -250,7 +250,7 @@
 
             result = true;
         } catch (e) {
-            self.emit("error", "Pipe error: " + e);
+            self.emit("error", "Connect Pipe error: " + e);
             self.disconnect();
         }
         


### PR DESCRIPTION
After troubleshooting some user-reported generator issues, I made two small changes to help make the logs clearer in the future.

1. When loading plugins, include both the version and the path in the log output.  This may help quickly determine if an unexpected plugin is loaded when collisions exist
1. Slightly clear up the trail of some mysterious EPIPE errors that show up occasionally in user reports