### PR TITLE
Allow zero values for JPG quality

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -28,13 +28,14 @@
         Q = require("q");
 
     // Constants
-    var DEFAULT_IMAGE_QUALITY           = 90,
+    var DEFAULT_IMAGE_QUALITY           = "90",
         BACKGROUND_COLOR_FOR_FLATTENING = "#fff";
 
     function _getConvertArgumentsForSettings(settings, binaryPaths) {
         var args    = [],
             format  = settings.format,
-            quality = settings.quality ? String(settings.quality) : null,
+            intQuality = Number.parseInt(settings.quality, 10),
+            quality = Number.isInteger(intQuality) ? String(intQuality) : DEFAULT_IMAGE_QUALITY,
             lossless = settings.lossless,
             _scale = settings._scale ? parseFloat(settings._scale) : 1.0;
 
@@ -88,7 +89,6 @@
             }
         }
         if (format === "jpg" || format === "webp") {
-            quality = quality || DEFAULT_IMAGE_QUALITY;
             args.push("-quality", quality);
         }
         if (format === "webp") {


### PR DESCRIPTION
Change the `convert` process to allow a `zero` quality value.  This is a marginally gross implementation, but the idea is to maintain consistency with the string comparisons later in the function (for non-jpg qualities), and be safe for both zero and float values should they creep in.