### PR TITLE
We shouldn't assume that the bounds we get will be pixel aligned,

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1331,6 +1331,8 @@
             visibleInputHeight  = visibleInputBounds.bottom - visibleInputBounds.top,
             paddedInputWidth    = paddedInputBounds.right   - paddedInputBounds.left,
             paddedInputHeight   = paddedInputBounds.bottom  - paddedInputBounds.top,
+            pixelAlignedInputHeight = Math.ceil(visibleInputBounds.bottom) - Math.floor(visibleInputBounds.top),
+            pixelAlignedInputWidth = Math.ceil(visibleInputBounds.right) - Math.floor(visibleInputBounds.left),
             
             // How much of the width is due to effects
             effectsInputWidth   = visibleInputWidth  - staticInputWidth,
@@ -1368,10 +1370,11 @@
                                     (effectsInputHeight * (finalOutputScaleY - 1)) /
                                     (staticInputHeight + paddingInputHeight),
 
+
             // The expected size of the pixmap returned by Photoshop (does not include padding)
-            visibleOutputWidth  = effectsScaled ? scaleX * visibleInputWidth :
+            visibleOutputWidth  = effectsScaled ? scaleX * pixelAlignedInputWidth :
                                                         scaleX * staticInputWidth + effectsInputWidth,
-            visibleOutputHeight = effectsScaled ? scaleY * visibleInputHeight :
+            visibleOutputHeight = effectsScaled ? scaleY * pixelAlignedInputHeight :
                                                         scaleY * staticInputHeight + effectsInputHeight;
 
 


### PR DESCRIPTION
 This change prevents us from trying to crop pixmaps we recieve down to non pixel aligned boundaries

This is a more targeted( but higher risk ) fix for issue https://github.com/adobe-photoshop/generator-assets/issues/350

and is an alternate to the more heavy handed approach in https://github.com/adobe-photoshop/generator-assets/pull/406 