### PR TITLE
Force ImageMagick instead of FLITE for pdf conversion

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -200,8 +200,9 @@
     }
     
     function _shouldUseFlite(settings, binaryPaths) {
-        //for now don't use FLITE for Gif (the palette building code works but could be improved)
-        return settings.useFlite && binaryPaths.flite && settings.format !== "gif";
+        // For now, don't use FLITE for GIF (the palette building code works but could be improved)
+        // nor for PDF which is used by DesignSpace and only supported by IM.  May not be supported long term.
+        return settings.useFlite && binaryPaths.flite && settings.format !== "gif" && settings.format !== "pdf";
     }
 
     function _pipeThroughPNGQuant(binaryPaths, inputStream, outputStream, outputCompleteDeferred) {


### PR DESCRIPTION
Design Space allows PDF export, although the feature is probably lamer than the user might expect; It just uses ImageMagick to generate a PDF from the pixmap.  When DS moved to using FLITE by default, PDF export stopped working.  This change will revert pdf exports back to using ImageMagick.  cc @chadrolfs 