### PR TITLE
getDeepbounds should return parent bounds for empty group

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1245,7 +1245,7 @@
     Generator.prototype.getDeepBounds = function (layer) {
         var bounds;
 
-        if (!layer.layers) {
+        if (!layer.layers || layer.layers.length === 0) {
             bounds = layer.bounds;
         } else {
             layer.layers.forEach(function (sub) {


### PR DESCRIPTION
This reports a better error when trying to export empty groups.  `getDeepBounds` was returning undefined for empty groups.  Now it will return the group's bounds (which are probably zero bounds, but that is handled correctly downstream)

old error
`Render failed: button targett - mask.png [TypeError: Cannot read property 'top' of undefined]`

new error
`Render failed: button targettt- mask.png { [Error: Refusing to render pixmap with zero bounds.] zeroBoundsError: true }`