### PR TITLE
Only write generator log messages to the log file, not stdout, unless -v arg is used

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,13 @@
 (function () {
     "use strict";
 
-    var utils = require("./lib/utils");
+    var util = require("util"),
+        optimist = require("optimist"),
+        Q = require("q"),
+        config = require("./lib/config").getConfig(),
+        generator = require("./lib/generator"),
+        stdlog = require("./lib/stdlog"),
+        utils = require("./lib/utils");
 
     var PLUGIN_KEY_PREFIX = "PLUGIN-";
 
@@ -36,20 +42,6 @@
         utils.filterWriteStream(process.stderr, utils.replaceBullet);
     }
     
-    require("./lib/stdlog").setup({
-        vendor:      "Adobe",
-        application: "Adobe Photoshop CC 2015.5",
-        module:      "Generator"
-    });
-
-
-    var util = require("util"),
-        config = require("./lib/config").getConfig(),
-        generator = require("./lib/generator"),
-        Q = require("q"),
-        optimist = require("optimist");
-
-
     var optionParser = optimist["default"]({
         "p" : 49494,
         "h" : "127.0.0.1",
@@ -72,6 +64,7 @@
             "i": "file descriptor of input pipe",
             "o": "file descriptor of output pipe",
             "f": "folder to search for plugins (can be used multiple times)",
+            "v": "include verbose generator logging in stdout",
             "photoshopVersion": "tell Generator PS's version so it isn't queried at startup (optional)",
             "photoshopPath": "tell Generator PS's path so it isn't queried at startup (optional)",
             "photoshopBinaryPath": "tell Generator PS's binary location so it isn't queried at startup (optional)",
@@ -83,13 +76,25 @@
             "P": "password",
             "i": "input",
             "o": "output",
-            "f": "pluginfolder"
+            "f": "pluginfolder",
+            "v": "verbose"
         }).argv;
     
     if (argv.help) {
         console.log(optimist.help());
         process.exit(0);
     }
+
+    var logSettings = {
+        vendor:      "Adobe",
+        application: "Adobe Photoshop CC 2015.5",
+        module:      "Generator",
+        verbose:     argv.verbose
+    };
+
+    // Initialize log file writer
+    // This will tap stdout and read generator-logger's readable stream
+    stdlog.setup(logSettings, generator.logStream);
 
     function stop(exitCode, reason) {
         if (!reason) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -23,13 +23,11 @@
 
 (function () {
     "use strict";
-    
+
     var logging = require("./logging"),
         _loggerManager = new logging.LoggerManager(logging.LOG_LEVEL_DEBUG),
         _logger = _loggerManager.createLogger("core"),
-        _formatter = new logging.StreamFormatter(_loggerManager);
-
-    _formatter.pipe(process.stdout);
+        logStream = new logging.StreamFormatter(_loggerManager);
 
     var EventEmitter = require("events").EventEmitter,
         Q = require("q"),
@@ -2026,6 +2024,7 @@
             
     exports.Generator         = Generator;
     exports.createGenerator   = createGenerator;
+    exports.logStream         = logStream;
     exports._escapePluginId   = escapePluginId;
     exports._unescapePluginId = unescapePluginId;
         

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -353,7 +353,7 @@
 
                 entryString += "\n";
 
-                this._pushable = this.push(entryString);
+                this._pushable = this.push(entryString, "utf8");
             }
         }
     };

--- a/lib/stdlog.js
+++ b/lib/stdlog.js
@@ -70,17 +70,65 @@
 
     // Use tail -F logs/generator_latest.txt to see the latest output
 
-    function writeToLog(data, encoding) {
+    function writeToLog(chunk, encoding, colorFunction) {
+        // We stopped logging in a previous call to write: return now
+        if (_logBytesWritten > LOG_SIZE_LIMIT) { return; }
+
+        var chunkLength,
+            logMsg;
+
+        if (!Buffer.isBuffer(chunk)) {
+            chunk = String(chunk);
+            if (colorFunction) {
+                chunk = colorFunction(chunk);
+            }
+            chunkLength = Buffer.byteLength(chunk, encoding);
+        } else {
+            chunkLength = chunk.length;
+        }
+
+        // Calculate the new log file size
+        _logBytesWritten += chunkLength;
+
+        // Limit not yet reached: write to log file
+        if (_logBytesWritten > LOG_SIZE_LIMIT) {
+            logMsg = "The log file size limit of " + LOG_SIZE_LIMIT + " bytes was reached." +
+                " No further output will be written to this file.";
+        } else {
+            logMsg = chunk;
+        }
+
         _logFilePaths.forEach(function (path) {
             try {
-                fs.appendFileSync(path, data, { encoding: encoding });
+                fs.appendFileSync(path, logMsg, { encoding: encoding });
             } catch (e) {
                 // do nothing
             }
         });
     }
 
-    function logStream(stream, colorFunction) {
+    /**
+     * Listen for data on a readable stream, write to the log file
+     *
+     * @param {stream.Readable} stream
+     */
+    function logReadableStream(stream) {
+        var encoding = "utf8";
+
+        stream.setEncoding(encoding);
+
+        stream.on("data", function (chunk) {
+            writeToLog(chunk, encoding);
+        });
+    }
+
+    /**
+     * Tap a writable stream and write the data to the log file
+     *
+     * @param {stream.Writable} stream
+     * @param {function=} colorFunction optional function to apply color to the log message
+     */
+    function logWriteableStream(stream, colorFunction) {
         var write = stream.write;
         
         // The third parameter, callback, will be passed implicitely using arguments
@@ -90,32 +138,7 @@
                 write.apply(this, arguments);
             } catch (streamWriteError) { }
             
-            // We stopped logging in a previous call to write: return now
-            if (_logBytesWritten > LOG_SIZE_LIMIT) { return; }
-
-            var chunkLength;
-
-            if (!Buffer.isBuffer(chunk)) {
-                chunk = String(chunk);
-                if (colorFunction) {
-                    chunk = colorFunction(chunk);
-                }
-                chunkLength = Buffer.byteLength(chunk, encoding);
-            } else {
-                chunkLength = chunk.length;
-            }
-            
-            // Calculate the new log file size
-            _logBytesWritten += chunkLength;
-
-            // Limit not yet reached: write to log file
-            if (_logBytesWritten > LOG_SIZE_LIMIT) {
-                writeToLog("The log file size limit of " + LOG_SIZE_LIMIT + " bytes was reached." +
-                    " No further output will be written to this file.");
-                return;
-            }
-            
-            writeToLog(chunk, encoding);
+            writeToLog(chunk, encoding, colorFunction);
         };
     }
 
@@ -162,7 +185,7 @@
         }
     }
 
-    function setup(settings) {
+    function setup(settings, logStream) {
         try {
             // Create the log file directory
             _logDir = createDirectoryWithElements(getLogDirectoryElements(settings));
@@ -178,11 +201,22 @@
         
         _logFilePaths.push(resolve(_logDir, REGULAR_LOG_NAMES[0]));
 
-        logStream(process.stdout);
-        // Print output via STDERR in red
-        logStream(process.stderr, function (string) {
+        // Always write stdout to log file
+        logWriteableStream(process.stdout);
+        // write STDERR in red
+        logWriteableStream(process.stderr, function (string) {
             return "\x1B[1;31m" + string + "\x1B[0m";
         });
+
+        // In verbose mode, write the generator log stream to stdout (which then goes on to the log file)
+        // Otherwise, use logReadableStream to write directly to the generator log file
+        if (settings.verbose) {
+            logStream.pipe(process.stdout);
+        } else {
+            console.log("Logging Generator in directory: %s", _logDir);
+            console.log("Use '-v' option to print logs to stdout");
+            logReadableStream(logStream);
+        }
 
         writeToLog("Log file created on " + new Date() + "\n\n");
     }


### PR DESCRIPTION
This PR prevents noisy debug logs from being written to the node process stdout which then prevents them from cluttering up the photoshop log.  The PR also provides a new "-v" command line switch for `generator` which *does* route debug logging info to stdout so that developers can watch the logs in the terminal like the good old days.

Three important bits:

1. Exposed `generator.logStream`, the readable log stream from the generator module instead of piping it directly to `process.stdout` inside of `generator.js`
1. In `lib/stdlog.js`, added a new method `logReadableStream` to be used in the non-verbose case to siphon logging messages into the log file, bypassing `stdout`.  Otherwise pipe to `stdout`
1. Add "-v" option in app.js and pass that flag to stdlog

There are a few very minor refactoring and/or code-tidying changes.

Alternate option: we could flip it so the argument is "-q" to suppress logs, making it more backwards compatible for "generator developers".  But that would require a PS change!  To make it more palatable, we print two helpful messages to stdout in non-verbose mode.

A further enhancement could be the selective inclusion of ERROR messages in stdout while maintaining ALL messages in the log file.