### PR TITLE
add photoshop promise reject on error

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -114,8 +114,10 @@
             });
 
             self._photoshop.on("close", function () {
-                _logger.info("Photoshop connection closed");
+                var msg = "Photoshop connection closed";
+                _logger.info(msg);
                 self.emit("close");
+                connectionDeferred.reject(msg);
             });
 
             self._photoshop.on("error", function (err) {
@@ -128,7 +130,9 @@
             });
 
             self._photoshop.on("communicationsError", function (err, rawMessage) {
-                _logger.warn("photoshop communications error: %j", {error: err, rawMessage: rawMessage});
+                var msg = "photoshop communications error: %j", {error: err, rawMessage: rawMessage};
+                _logger.warn(msg);
+                connectionDeferred.reject(msg);
             });
 
             self._photoshop.on("message", function (messageID, parsedValue) { // ,rawMessage)


### PR DESCRIPTION
i use generator-core as lib, when photoshop connect fail, i can't catch error handle.

this patch fix it.