### PR TITLE
fix to use document clipping bounds on document pixmaps, and to not use extract paramaters

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1118,6 +1118,8 @@
                     lastLayerIndex: document.layers[0].index,
                     hidden: this._computeHiddenLayers(document)
                 };
+                delete settings.getExtractParamsForDocBounds;
+                settings.clipToDocumentBounds = true;
                 return this.getPixmap(documentId, layerSpec, settings || {});
             }.bind(this));
         }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1118,8 +1118,10 @@
                     lastLayerIndex: document.layers[0].index,
                     hidden: this._computeHiddenLayers(document)
                 };
-                delete settings.getExtractParamsForDocBounds;
-                settings.clipToDocumentBounds = true;
+                if (settings.inputRect === undefined && settings.outputRect === undefined) {
+                    delete settings.getExtractParamsForDocBounds;
+                    settings.clipToDocumentBounds = true;
+                }
                 return this.getPixmap(documentId, layerSpec, settings || {});
             }.bind(this));
         }


### PR DESCRIPTION
After talking with TBone, This fix for the document level bounds issues we've been seeing seems cleaner than the other proposed solutions. 