### PR TITLE
New 'shared engine' message type when sending JSX to photoshop

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,8 @@ module.exports = function (grunt) {
 
         jshint : {
             options : {
-                jshintrc : ".jshintrc"
+                jshintrc : ".jshintrc",
+                reporterOutput: ""
             },
             js : [
                 "*.js",

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -25,7 +25,7 @@
     "use strict";
 
     var logging = require("./logging"),
-        _loggerManager = new logging.LoggerManager(logging.LOG_LEVEL_DEBUG),
+        _loggerManager = new logging.LoggerManager(logging.LOG_LEVEL_INFO),
         _logger = _loggerManager.createLogger("core"),
         logStream = new logging.StreamFormatter(_loggerManager);
 
@@ -100,9 +100,9 @@
         self._options = options;
         self._config = options.config || {};
         
-        _logger.debug("Launching with config:\n%s", JSON.stringify(self._config, null, "  "));
+        _logger.info("Launching with config:\n%s", JSON.stringify(self._config, null, "  "));
         if (options.photoshopVersion) {
-            _logger.debug("provided PS information:\n version %s\n path%s\n",
+            _logger.info("provided PS information:\n version %s\n path%s\n",
                 options.photoshopVersion, options.photoshopPath);
         }
 
@@ -354,7 +354,7 @@
         };
 
         Q.spread([loadJSX(path), stringifyParams(params)], function (jsx, paramsString) {
-            // _logger.log("Sending JSX file with params", path, paramsString);
+            _logger.debug("Sending JSX file with params", path, paramsString);
             var data = "var params = " + paramsString + ";\n" + jsx;
             self._sendJSXString(data, deferred, sharedEngineSafe);
         })
@@ -1866,7 +1866,7 @@
 
         // Do the actual plugin load
         try {
-            _logger.debug("Loading plugin: %s (v%s) from directory: %s", metadata.name, metadata.version, directory);
+            _logger.info("Loading plugin: %s (v%s) from directory: %s", metadata.name, metadata.version, directory);
             // NOTE: We don't need to worry about accidentally requiring the same plugin twice.
             // If the user did try to load it twice, require's caching would return the same
             // package.json both times (even if the package.json changed on disk), and so
@@ -1882,7 +1882,7 @@
                 config: config,
                 logger: logger
             };
-            _logger.debug("Plugin loaded: %s", metadata.name);
+            _logger.info("Plugin loaded: %s", metadata.name);
             self._logHeadlights("Plugin loaded: " + metadata.name);
             self._logHeadlights("Plugin version: " + metadata.name + ":" + metadata.version);
         } catch (loadError) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -254,35 +254,43 @@
             });
     };
 
-    // Note: This is a private method. Call at your own risk, and follow instructions below.
-    // Most users of the Generator API will want the public Generator.prototype.evaluateJSXString
-    // method below.
-    //
-    // This method returns a deferred (not a promise). Every time a message comes in from Photoshop
-    // pertaining to this call, a "progress" notification is issued on the deferred. When the caller of
-    // this method is no longer interested in any more messages, it is the responsibility of the
-    // caller to resolve the returned deferred. Doing that will cause the necessary cleanup
-    // to happen internally (via a "finally" handler that this method installs on the deferred).
-    //
-    // The progress notification will be an object of the form:
-    //    { type : [string like "javascript" or "pixmap" or "iccProfile"],
-    //      value : [dependent on type -- Object if "javascript", Buffer if "pixmap" or "iccProfile"] }
-    //
-    // If the caller of this message never resolves/rejects the returned deferred, then we'll have a
-    // memory leak on our hands.
-    // 
-    // Optionally, the caller of this method can specify its own deferred object to use. If one is not
-    // provided, then a new deferred will be constructed. In either case, the deferred that will receive
-    // progress notifications is returned.
-    //
-    // The reason this method (and _sendJSXFile) exist is because some Generator-specific ExtendScript
-    // returns multiple JS messages, and we need a way to handle that. However, all other general-purpose
-    // ExtendScript will only return one (which is what the public API expects). As we
-    // move Generator things out of ExtendScript (or add more stuff to Generator), the requirements
-    // of this method (and _sendJSXFile) may change. That's why it's private.
-    Generator.prototype._sendJSXString = function (s, deferred) {
+    /**
+     * Note: This is a private method. Call at your own risk, and follow instructions below.
+     * Most users of the Generator API will want the public Generator.prototype.evaluateJSXString
+     * method below.
+     *
+     * This method returns a deferred (not a promise). Every time a message comes in from Photoshop
+     * pertaining to this call, a "progress" notification is issued on the deferred. When the caller of
+     * this method is no longer interested in any more messages, it is the responsibility of the
+     * caller to resolve the returned deferred. Doing that will cause the necessary cleanup
+     * to happen internally (via a "finally" handler that this method installs on the deferred).
+     *
+     * The progress notification will be an object of the form:
+     * { type : [string like "javascript" or "pixmap" or "iccProfile"],
+     * value : [dependent on type -- Object if "javascript", Buffer if "pixmap" or "iccProfile"] }
+     *
+     * If the caller of this message never resolves/rejects the returned deferred, then we'll have a
+     * memory leak on our hands.
+     *
+     * Optionally, the caller of this method can specify its own deferred object to use. If one is not
+     * provided, then a new deferred will be constructed. In either case, the deferred that will receive
+     * progress notifications is returned.
+     *
+     * The reason this method (and _sendJSXFile) exist is because some Generator-specific ExtendScript
+     * returns multiple JS messages, and we need a way to handle that. However, all other general-purpose
+     * ExtendScript will only return one (which is what the public API expects). As we
+     * move Generator things out of ExtendScript (or add more stuff to Generator), the requirements
+     * of this method (and _sendJSXFile) may change. That's why it's private.
+     *
+     * @private
+     * @param {string} s JSX string to execute
+     * @param {Deferred=} deferred
+     * @param {boolean=} sharedEngineSafe Optional, if true allow PS to use a shared script engine
+     * @return {Deferred}
+     */
+    Generator.prototype._sendJSXString = function (s, deferred, sharedEngineSafe) {
         var self = this,
-            id = self._photoshop.sendCommand(s);
+            id = self._photoshop.sendCommand(s, sharedEngineSafe);
 
         deferred = deferred || Q.defer();
             
@@ -295,13 +303,22 @@
         return deferred;
     };
 
-    // Note: This is a private method. Call at your own risk, and follow instructions above for _sendJSXString.
-    // Most users of the Generator API will want the public Generator.prototype.evaluateJSXFile
-    // method below.
-    //
-    // See the comment for _sendJSXString above for details on how to use this if you really
-    // need to use it.
-    Generator.prototype._sendJSXFile = function (path, params) {
+
+    /**
+     * Note: This is a private method. Call at your own risk, and follow instructions above for _sendJSXString.
+     * Most users of the Generator API will want the public Generator.prototype.evaluateJSXFile
+     * method below.
+     *
+     * See the comment for _sendJSXString above for details on how to use this if you really
+     * need to use it.
+     *
+     * @private
+     * @param {string} path
+     * @param {object=} params
+     * @param {boolean=} sharedEngineSafe
+     * @return {Deferred}
+     */
+    Generator.prototype._sendJSXFile = function (path, params, sharedEngineSafe) {
         var self = this,
             deferred = Q.defer();
 
@@ -337,8 +354,9 @@
         };
 
         Q.spread([loadJSX(path), stringifyParams(params)], function (jsx, paramsString) {
+            // _logger.log("Sending JSX file with params", path, paramsString);
             var data = "var params = " + paramsString + ";\n" + jsx;
-            self._sendJSXString(data, deferred);
+            self._sendJSXString(data, deferred, sharedEngineSafe);
         })
         .fail(function (err) {
             deferred.reject(err);
@@ -348,9 +366,17 @@
 
     };
 
-    Generator.prototype.evaluateJSXFile = function (path, params) {
+    /**
+     * Evaluate a local JSX file with optional parameters inserted
+     *
+     * @param {string} path
+     * @param {object=} params
+     * @param {boolean=} sharedEngineSafe Optional, if true allow PS to use a shared script engine
+     * @return {Promise}
+     */
+    Generator.prototype.evaluateJSXFile = function (path, params, sharedEngineSafe) {
         var self = this,
-            deferred = self._sendJSXFile(path, params);
+            deferred = self._sendJSXFile(path, params, sharedEngineSafe);
 
         deferred.promise.progress(function (message) {
             if (message.type === "javascript") {
@@ -361,9 +387,27 @@
         return deferred.promise;
     };
 
-    Generator.prototype.evaluateJSXString = function (s) {
+    /**
+     * Wrapper for evaluateJSXFile, using Shared Engine Safe mode
+     *
+     * @param {string} s
+     * @param {object=} params
+     * @return {Promise}
+     */
+    Generator.prototype.evaluateJSXFileSharedSafe = function (path, params) {
+        return this.evaluateJSXFile(path, params, true);
+    }
+
+    /**
+     * Evaluate a JSX string
+     *
+     * @param {string} s
+     * @param {boolean=} sharedEngineSafe Optional, if true allow PS to use a shared script engine
+     * @return {Promise}
+     */
+    Generator.prototype.evaluateJSXString = function (s, sharedEngineSafe) {
         var self = this,
-            deferred = self._sendJSXString(s);
+            deferred = self._sendJSXString(s, undefined, sharedEngineSafe);
 
         deferred.promise.progress(function (message) {
             if (message.type === "javascript") {
@@ -374,8 +418,24 @@
         return deferred.promise;
     };
 
+    /**
+     * Wrapper for evaluateJSXString, using Shared Engine Safe mode
+     *
+     * @param {string} s
+     * @return {Promise}
+     */
+    Generator.prototype.evaluateJSXStringSharedSafe = function (s) {
+        return this.evaluateJSXString(s, true);
+    }
+
+    /**
+     * Simple window alert
+     *
+     * @param {string} message
+     * @param {string} stringReplacements
+     */
     Generator.prototype.alert = function (message, stringReplacements) {
-        this.evaluateJSXFile("./jsx/alert.jsx", { message: message, replacements: stringReplacements });
+        this.evaluateJSXFileSharedSafe("./jsx/alert.jsx", { message: message, replacements: stringReplacements });
     };
 
     /**
@@ -384,7 +444,7 @@
      * @param {!string} str The String
      */
     Generator.prototype.copyToClipboard = function (str) {
-        this.evaluateJSXFile("./jsx/copyToClipboard.jsx", { clipboard: str });
+        this.evaluateJSXFileSharedSafe("./jsx/copyToClipboard.jsx", { clipboard: str });
     };
 
     /**
@@ -402,7 +462,7 @@
      */
     Generator.prototype.getPhotoshopPath = function () {
         if (!this._options.photoshopPath) {
-            return this.evaluateJSXString("File(app.path).fsName");
+            return this.evaluateJSXStringSharedSafe("File(app.path).fsName");
         } else {
             return Q.fcall(function () {
                 return this._options.photoshopPath;
@@ -429,7 +489,7 @@
      */
     Generator.prototype.getPhotoshopExecutableLocation = function () {
         if (!this._options.photoshopBinaryPath) {
-            return this.evaluateJSXFile("./jsx/getPhotoshopExecutableLocation.jsx", {});
+            return this.evaluateJSXFileSharedSafe("./jsx/getPhotoshopExecutableLocation.jsx", {});
         } else {
             return Q.fcall(function () {
                 return this._options.photoshopBinaryPath;
@@ -438,7 +498,7 @@
     };
 
     Generator.prototype.getPhotoshopLocale = function () {
-        return this.evaluateJSXString("app.locale");
+        return this.evaluateJSXStringSharedSafe("app.locale");
     };
 
     /**
@@ -448,7 +508,7 @@
      */
     Generator.prototype.getPhotoshopVersion = function () {
         if (!this._options.photoshopVersion) {
-            return this.evaluateJSXFile("./jsx/getPhotoshopVersion.jsx", {});
+            return this.evaluateJSXFileSharedSafe("./jsx/getPhotoshopVersion.jsx", {});
         } else {
             return Q.fcall(function () {
                 return this._options.photoshopVersion;
@@ -473,7 +533,7 @@
                 menuItems.push(this._menuState[m]);
             }
         }
-        return this.evaluateJSXFile("./jsx/buildMenu.jsx", {items : menuItems});
+        return this.evaluateJSXFileSharedSafe("./jsx/buildMenu.jsx", {items : menuItems});
     };
 
     /**
@@ -500,7 +560,7 @@
                 params.displayName = displayName;
             }
             
-            return this.evaluateJSXFile("./jsx/toggleMenu.jsx", params);
+            return this.evaluateJSXFileSharedSafe("./jsx/toggleMenu.jsx", params);
         } else {
             var toggleFailedDeferred = Q.defer();
             toggleFailedDeferred.reject("no menu with ID " + name);
@@ -526,7 +586,7 @@
      * Returns a promise that resolves to an array of integers.
      */
     Generator.prototype.getOpenDocumentIDs = function () {
-        return this.evaluateJSXFile("./jsx/getOpenDocumentIDs.jsx", {}).then(function (ids) {
+        return this.evaluateJSXFileSharedSafe("./jsx/getOpenDocumentIDs.jsx", {}).then(function (ids) {
             if (typeof ids === "number") {
                 return [ids];
             } else if (typeof ids === "string" && ids.length > 0) {
@@ -596,7 +656,7 @@
             });
         }
 
-        return this.evaluateJSXFile("./jsx/getDocumentInfo.jsx", params);
+        return this.evaluateJSXFileSharedSafe("./jsx/getDocumentInfo.jsx", params);
     };
 
     /**
@@ -659,7 +719,7 @@
                 key: escapePluginId(pluginId)
             };
 
-        return this.evaluateJSXFile("./jsx/getGeneratorSettings.jsx", params)
+        return this.evaluateJSXFileSharedSafe("./jsx/getGeneratorSettings.jsx", params)
             .then(function (settings) {
                 //even though it says "document" it works with any generatorSettings node
                 return self.extractDocumentSettings(settings);
@@ -683,7 +743,7 @@
                 settings: { json: JSON.stringify(settings) }
             };
 
-        return this.evaluateJSXFile("./jsx/setGeneratorSettings.jsx", params);
+        return this.evaluateJSXFileSharedSafe("./jsx/setGeneratorSettings.jsx", params);
     };
     
     /**
@@ -700,7 +760,7 @@
                 key: escapePluginId(pluginId)
             };
 
-        return this.evaluateJSXFile("./jsx/getGeneratorSettings.jsx", params)
+        return this.evaluateJSXFileSharedSafe("./jsx/getGeneratorSettings.jsx", params)
             .then(function (settings) {
                 // Don't pass the plugin ID here because due to using params.key above,
                 // {{ generatorSettings: { <pluginId>: <settings> }} is shortened to
@@ -724,7 +784,7 @@
                 settings: { json: JSON.stringify(settings) }
             };
 
-        return this.evaluateJSXFile("./jsx/setGeneratorSettings.jsx", params);
+        return this.evaluateJSXFileSharedSafe("./jsx/setGeneratorSettings.jsx", params);
     };
 
     /**
@@ -800,7 +860,7 @@
 
         if (events.length > 0) {
             var params = { events : events };
-            return self.evaluateJSXFile("./jsx/networkEventSubscribe.jsx", params);
+            return self.evaluateJSXFileSharedSafe("./jsx/networkEventSubscribe.jsx", params);
         } else {
             return new Q(true);
         }
@@ -1025,7 +1085,7 @@
         // where it wasn't necessary. But the logic is much simpler if we just create it and then resolve it
         // in cases where we don't need it. When the day comes that Generator is slow because we create one
         // extra deferred every time we generate an image, we'll optimize this.
-        executionDeferred = self._sendJSXFile("./jsx/getLayerPixmap.jsx", params);
+        executionDeferred = self._sendJSXFile("./jsx/getLayerPixmap.jsx", params, true);
 
         executionDeferred.promise.progress(function (message) {
             if (message.type === "javascript") {
@@ -1160,7 +1220,7 @@
             timeoutTimer = null,
             resultDeferred = Q.defer(),
             executionDeferred = self._sendJSXFile("./jsx/getLayerShape.jsx",
-                {documentId : documentId, layerId : layerId});
+                {documentId : documentId, layerId : layerId}, true);
 
         resultDeferred.promise.finally(function () {
             executionDeferred.resolve(); // done listening for messages
@@ -1649,7 +1709,7 @@
         };
         
 
-        return (this.evaluateJSXFile("./jsx/getLayerSVG.jsx", params)
+        return (this.evaluateJSXFileSharedSafe("./jsx/getLayerSVG.jsx", params)
             .then(function (result) {
                 return decodeURI(result.svgText);
             })
@@ -1669,7 +1729,7 @@
         if (documentId === undefined) {
             return Q.reject("Document ID is required");
         } else {
-            return this.evaluateJSXFile("./jsx/getGuides.jsx", { documentId: documentId })
+            return this.evaluateJSXFileSharedSafe("./jsx/getGuides.jsx", { documentId: documentId })
                 .then(function (serializedGuides) {
                     var guideParts = serializedGuides.split(";").map(function (guides) {
                         // when no guides in this direction
@@ -1703,7 +1763,7 @@
      *  @return {Promise} resolved/rejected when request completes/errors
      */
     Generator.prototype._logHeadlights = function (event) {
-        return this.evaluateJSXFile("./jsx/logHeadlights.jsx", { event : event });
+        return this.evaluateJSXFileSharedSafe("./jsx/logHeadlights.jsx", { event : event });
     };
         
     Generator.prototype.shutdown = function () {
@@ -1869,7 +1929,7 @@
 
         // We stored stringified settings, but the Photoshop connection tries to
         // parse JSON responses from ExtendScript automatically. 
-        return this.evaluateJSXFile("./jsx/getCustomOptions.jsx", params)
+        return this.evaluateJSXFileSharedSafe("./jsx/getCustomOptions.jsx", params)
             .then(function (settings) {
                 if (typeof settings === "object") {
                     return settings;
@@ -1916,7 +1976,7 @@
             persistent: false
         };
 
-        return this.evaluateJSXFile("./jsx/setCustomOptions.jsx", params);
+        return this.evaluateJSXFileSharedSafe("./jsx/setCustomOptions.jsx", params);
     };
 
     /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -390,13 +390,13 @@
     /**
      * Wrapper for evaluateJSXFile, using Shared Engine Safe mode
      *
-     * @param {string} s
+     * @param {string} path
      * @param {object=} params
      * @return {Promise}
      */
     Generator.prototype.evaluateJSXFileSharedSafe = function (path, params) {
         return this.evaluateJSXFile(path, params, true);
-    }
+    };
 
     /**
      * Evaluate a JSX string
@@ -426,7 +426,7 @@
      */
     Generator.prototype.evaluateJSXStringSharedSafe = function (s) {
         return this.evaluateJSXString(s, true);
-    }
+    };
 
     /**
      * Simple window alert

--- a/lib/jsx/buildMenu.jsx
+++ b/lib/jsx/buildMenu.jsx
@@ -14,9 +14,10 @@ var enabledID = stringIDToTypeID("enabled");
 var checkedID = stringIDToTypeID("checked");
 var nodeMenuInitializeID = stringIDToTypeID("nodeMenuInitialize");
 var nodeMenuID = stringIDToTypeID("nodeMenu");
-
 var list = new ActionList();
-var menu, i;
+
+var i,
+    menu = null;
 
 for (i = 0; i < params.items.length; i++) {
     menu = new ActionDescriptor();

--- a/lib/jsx/getCustomOptions.jsx
+++ b/lib/jsx/getCustomOptions.jsx
@@ -1,5 +1,6 @@
 /*global app, params */
 
+// getCustomOptions
 // Required param:
 //   - key: The id of the plugin for which to retrieve persistent settings
 

--- a/lib/jsx/getDocumentInfo.jsx
+++ b/lib/jsx/getDocumentInfo.jsx
@@ -17,11 +17,12 @@
 //   - documentId: The ID of the document requested (leave null for current document)
 
 var idNS = stringIDToTypeID("sendDocumentInfoToNetworkClient");
-var k, desc = new ActionDescriptor();
+var desc = new ActionDescriptor();
 desc.putString(stringIDToTypeID("version"), "1.0.1");
 
 var flags = params.flags;
 
+var k;
 for (k in flags) {
     if (flags.hasOwnProperty(k)) {
         desc.putBoolean(stringIDToTypeID(k), flags[k]);

--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -58,7 +58,7 @@
 var DEFAULT_MAX_DIMENSION = 10000;
 
 var actionDescriptor = new ActionDescriptor(),
-    transform;
+    transform = null;
 
 // Add a transform if necessary
 if (params.inputRect && params.outputRect) {

--- a/lib/jsx/getLayerSVG.jsx
+++ b/lib/jsx/getLayerSVG.jsx
@@ -47,18 +47,18 @@ if (typeof cssToClip === "undefined")
     $.evalFile(getPSAppPath() + appFolder[File.fs] + "Required/CopyCSSToClipboard.jsx");
 }
 
-const ksendLayerThumbnailToNetworkClientStr = app.stringIDToTypeID("sendLayerThumbnailToNetworkClient");
-const krawPixmapFilePathStr = app.stringIDToTypeID("rawPixmapFilePath");
+var ksendLayerThumbnailToNetworkClientStr = app.stringIDToTypeID("sendLayerThumbnailToNetworkClient");
+var krawPixmapFilePathStr = app.stringIDToTypeID("rawPixmapFilePath");
 
-const kformatStr = app.stringIDToTypeID("format");
-// const kselectedLayerStr = app.stringIDToTypeID("selectedLayer");
-const kwidthStr = app.stringIDToTypeID("width");
-const kheightStr = app.stringIDToTypeID("height");
-const kboundsStr = app.stringIDToTypeID("bounds");
-const klayerIDStr = app.stringIDToTypeID("layerID");
-const klayerSVGcoordinateOffset = app.stringIDToTypeID("layerSVGcoordinateOffset");
-const keyX = app.charIDToTypeID('X   ');
-const keyY = app.charIDToTypeID('Y   ');
+var kformatStr = app.stringIDToTypeID("format");
+// var kselectedLayerStr = app.stringIDToTypeID("selectedLayer");
+var kwidthStr = app.stringIDToTypeID("width");
+var kheightStr = app.stringIDToTypeID("height");
+var kboundsStr = app.stringIDToTypeID("bounds");
+var klayerIDStr = app.stringIDToTypeID("layerID");
+var klayerSVGcoordinateOffset = app.stringIDToTypeID("layerSVGcoordinateOffset");
+var keyX = app.charIDToTypeID('X   ');
+var keyY = app.charIDToTypeID('Y   ');
 
 
 function ConvertSVG()
@@ -1156,7 +1156,10 @@ svg.createSVGText = function ()
     // which is only available in PS v15 (CC 2014) and up.
     var fixBoundsAvailable = Number(app.version.match(/\d+/)) >= 15;
 
-    var bounds, savedLayer, curLayer = PSLayerInfo.layerIDToIndex(params.layerId);
+    var bounds = null,
+        savedLayer = null,
+        curLayer = PSLayerInfo.layerIDToIndex(params.layerId);
+
     this.setCurrentLayer(curLayer);
 
     svg.setLayerSVGOffset( 0.0, 0.0 );

--- a/lib/jsx/networkEventSubscribe.jsx
+++ b/lib/jsx/networkEventSubscribe.jsx
@@ -3,8 +3,9 @@
 // Required params:
 //   - events: Array of strings representing event names
 
-var i, actionDescriptor;
-actionDescriptor = new ActionDescriptor();
+var i,
+    actionDescriptor = new ActionDescriptor();
+
 actionDescriptor.putString(stringIDToTypeID("version"), "1.0.0");
 for (i = 0; i < params.events.length; i++) {
     actionDescriptor.putClass(stringIDToTypeID("eventIDAttr"), stringIDToTypeID(params.events[i]));

--- a/lib/jsx/setCustomOptions.jsx
+++ b/lib/jsx/setCustomOptions.jsx
@@ -1,7 +1,8 @@
 /*global ActionDescriptor, app, params */
 
+// setCustomOptions
 // Required params:
-//   - key: The id of the plugin for which to retrieve persistent settings
+//   - key: The id of the plugin for which to set persistent settings
 //   - settings: A JSON string representing persistent settings for the plugin
 // Optional param:
 //   - persistent: Boolean that indicates whether the settings should persist across launches

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -440,7 +440,7 @@
             payloadBuffer = new Buffer(codeBuffer.length + PAYLOAD_HEADER_LENGTH),
             messageType = sharedEngineSafe ? MESSAGE_TYPE_JAVASCRIPT_S : MESSAGE_TYPE_JAVASCRIPT;
 
-            // this._logger.log("sendCommand " + id + "with type " + messageType + ": " + javascript.substr(0, 150));
+        this._logger.debug("sendCommand " + id + "with type " + messageType + ": " + javascript.substr(0, 50));
 
         payloadBuffer.writeUInt32BE(PROTOCOL_VERSION, PAYLOAD_PROTOCOL_OFFSET);
         payloadBuffer.writeUInt32BE(id, PAYLOAD_ID_OFFSET);

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -63,7 +63,8 @@
         MAX_MESSAGE_ID            = 256 * 256 * 256,
         PROTOCOL_VERSION          = 1,
         MESSAGE_TYPE_ERROR        = 1,
-        MESSAGE_TYPE_JAVASCRIPT   = 2,
+        MESSAGE_TYPE_JAVASCRIPT   = 2,  // ExtendScript that requires refreshed scripting engine
+        MESSAGE_TYPE_JAVASCRIPT_S = 10, // ExtendScript that can reuse same scripting engine
         MESSAGE_TYPE_PIXMAP       = 3,
         MESSAGE_TYPE_ICC_PROFILE  = 4,
         MESSAGE_TYPE_KEEPALIVE    = 6,
@@ -424,14 +425,26 @@
         return id;
     };
 
-    PhotoshopClient.prototype.sendCommand = function (javascript) {
+    /**
+     * Send a JSX command to photoshop.
+     * Use a special message type in the message header
+     * if this script is designated safe for use with a scripting engine
+     *
+     * @param {string} javascript
+     * @param {boolean=} sharedEngineSafe
+     * @return {number} command ID
+     */
+    PhotoshopClient.prototype.sendCommand = function (javascript, sharedEngineSafe) {
         var id = this._lastMessageID = (this._lastMessageID + 1) % MAX_MESSAGE_ID,
             codeBuffer = new Buffer(javascript, "utf8"),
-            payloadBuffer = new Buffer(codeBuffer.length + PAYLOAD_HEADER_LENGTH);
-        
+            payloadBuffer = new Buffer(codeBuffer.length + PAYLOAD_HEADER_LENGTH),
+            messageType = sharedEngineSafe ? MESSAGE_TYPE_JAVASCRIPT_S : MESSAGE_TYPE_JAVASCRIPT;
+
+            // this._logger.log("sendCommand " + id + "with type " + messageType + ": " + javascript.substr(0, 150));
+
         payloadBuffer.writeUInt32BE(PROTOCOL_VERSION, PAYLOAD_PROTOCOL_OFFSET);
         payloadBuffer.writeUInt32BE(id, PAYLOAD_ID_OFFSET);
-        payloadBuffer.writeUInt32BE(MESSAGE_TYPE_JAVASCRIPT, PAYLOAD_TYPE_OFFSET);
+        payloadBuffer.writeUInt32BE(messageType, PAYLOAD_TYPE_OFFSET);
         codeBuffer.copy(payloadBuffer, PAYLOAD_HEADER_LENGTH);
 
         this._sendMessage(payloadBuffer);


### PR DESCRIPTION
The current Photoshop interface completely refreshes the extendscript engine each time generator executes a script.  This adds significant overhead that is especially noticeable during startup while generator is initializing itself.  A recent change in photoshop allows use of a *new* message type, supplied in the message header, that causes photoshop to use a shared extendscript engine.

This change is *not* in the shipping version of photoshop.

This PR provides an amended API for specifying the shared-engine-compatibililty of a given JSX string or file, and uses the new PS command message type when appropriate.  The existing methods will continue to use a non-shared engine by default, but an additional, optional parameter is now accepted.

- Fix existing JSX within this repo to be safe for shared engine execution; including removing instances of `const` declarations, and situations where `var`s could be declared but unassigned.
- Update internal JSX evaluations to use shared engine
- Add public 'sharedSafe' versions of JSX evaluation methods

Note: the other *known* instances of "unsafe" JSX scripts are in svgomg.  Work has been started to update those scripts, but it is not strictly necessary.