### PR TITLE
Require PS 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-core",
   "version": "3.10.1",
-  "photoshop-version": ">=18.0",
+  "photoshop-version": ">=19.0",
   "description": "Adobe Photoshop Generator Core",
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
At least because of the new shared engine safe message type