### PR TITLE
Add logger arg to convert/savePixmap

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -268,14 +268,14 @@
         return outputCompleteDeferred.promise;
     }
 
-    function savePixmap(binaryPaths, pixmap, path, settings) {
+    function savePixmap(binaryPaths, pixmap, path, settings, logger) {
         var fs = require("fs");
 
         // Open a stream to the output file.
         var fileStream = fs.createWriteStream(path);
 
         // Stream the pixmap into the file and resolve with path when successful.
-        return streamPixmap(binaryPaths, pixmap, fileStream, settings)
+        return streamPixmap(binaryPaths, pixmap, fileStream, settings, logger)
             .thenResolve(path)
             .catch(function (err) {
                 // If an error occurred, clean up the file.


### PR DESCRIPTION
This argument needs to be supplied to `savePixmap` so it can be passed to `streamPixmap`.   Note that the `logger` is already supplied to `savePixmap` by the generator-exposed wrapping method ... so this seems to have been an accidental omission:
```
    Generator.prototype.savePixmap = function (pixmap, path, settings) {
        this._parsePixmapProperties(pixmap);
        this._parsePixmapSaveSettings(settings);

        return convert.savePixmap(this._paths, pixmap, path, settings, _logger);
    };
```