### PR TITLE
Blacklist the device-preview plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "0.10"
+   - "4.3.1"
 before_script:
    - npm install -g grunt-cli
 script:

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -47,6 +47,13 @@
 
     var PLUGIN_INCOMPATIBLE_MESSAGE = "$$$/Generator/NotCompatibleString";
 
+    /**
+     * Set of plugin names that should be blocked from loading
+     *
+     * @type {Set}
+     */
+    var PLUGIN_BLACKLIST = new Set(["adobe-preview-generator-plugin"]);
+
     // Some commands result in multiple response messages. After the first response
     // message is received, if there's a gap longer than this in responses,
     // we assume there was an error.
@@ -1850,6 +1857,11 @@
             metadata = self.getPluginMetadata(directory);
         } catch (metadataError) {
             throw new Error("Could not load plugin: " + metadataError.message);
+        }
+
+        // Check against blacklist
+        if (PLUGIN_BLACKLIST.has(metadata.name)) {
+            throw new Error("Plugin is blacklisted");
         }
 
         // Check if it is compatible


### PR DESCRIPTION
We no longer support the device preview plugin but it might be installed in a global location.