### PR TITLE
Specify a digest (sha1) when deriving a key for remote generator

### DIFF
--- a/lib/ps_crypto.js
+++ b/lib/ps_crypto.js
@@ -36,6 +36,7 @@
         NUM_ITERATIONS = 1000,
         ALGORITHM = "des-ede3-cbc",
         KEY_LENGTH = 24,
+        DIGEST = "sha1",
         IV = new Buffer("000000005d260000", "hex"); // 0000 0000 5d26 0000    
     
     /**
@@ -61,7 +62,7 @@
     // -----------------
     
     function createPSCrypto(password, callback) {
-        crypto.pbkdf2(password, SALT, NUM_ITERATIONS, KEY_LENGTH, function (err, derivedKey) {
+        crypto.pbkdf2(password, SALT, NUM_ITERATIONS, KEY_LENGTH, DIGEST, function (err, derivedKey) {
             if (err) {
                 callback(err, null);
             } else {


### PR DESCRIPTION
See: node.js [crypto.pbkdf2](https://nodejs.org/docs/latest-v4.x/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback)

Addresses deprecation warning described in #385 

`sha1` has been the default value being used, this just makes it explicit.