### PR TITLE
Revert PR 379 because it causes regressions such as PS-12498. 

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1189,10 +1189,6 @@
                     lastLayerIndex: document.layers[0].index,
                     hidden: this._computeHiddenLayers(document)
                 };
-                if (settings.inputRect === undefined && settings.outputRect === undefined) {
-                    delete settings.getExtractParamsForDocBounds;
-                    settings.clipToDocumentBounds = true;
-                }
                 return this.getPixmap(documentId, layerSpec, settings || {});
             }.bind(this));
         }


### PR DESCRIPTION
The approach introduced in #379 does not work correctly for documents that contain transparent pixels AND layers that extend beyond the canvas bounds.   The alternate fix is provided by the heavy-handed fix generator-assets PR: https://github.com/adobe-photoshop/generator-assets/pull/439 