### PR TITLE
Remove direct console logging

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,7 +69,6 @@
                     if (addition && addition instanceof Object) {
                         merge(config, addition);
                     }
-                    console.log("Parsed config file: " + loc);
                 } catch (e) {
                     // do nothing
                 }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -108,7 +108,7 @@
         return args;
     }
 
-    function _getConvertArguments(binaryPaths, pixmap, settings) {
+    function _getConvertArguments(binaryPaths, pixmap, settings, logger) {
         var finalWidth = pixmap.width,
             finalHeight = pixmap.height;
 
@@ -126,7 +126,7 @@
             // Pass information about the image's pixel density
             args.push("-units", "PixelsPerInch", "-density", settings.ppi);
         } else {
-            console.warn("Did not pass the document's resolution because it is not a valid number:", settings.ppi);
+            logger.warn("Did not pass the document's resolution because it is not a valid number:", settings.ppi);
         }
 
         if (settings.extract && Number.isFinite(settings.extract.width) && settings.extract.width > 0 &&
@@ -220,7 +220,7 @@
     function streamPixmap(binaryPaths, pixmap, outputStream, settings, logger) {
         var outputCompleteDeferred = Q.defer();
 
-        var args = _getConvertArguments(binaryPaths, pixmap, settings);
+        var args = _getConvertArguments(binaryPaths, pixmap, settings, logger);
 
         // Launch convert
         var convertProc = (_shouldUseFlite(settings, binaryPaths) ?
@@ -282,14 +282,14 @@
                 try {
                     fileStream.close();
                 } catch (e) {
-                    console.error("Error when closing file stream", e);
+                    logger.error("Error when closing file stream", e);
                 }
                 try {
                     if (fs.existsSync(path)) {
                         fs.unlinkSync(path);
                     }
                 } catch (e) {
-                    console.error("Error when deleting file", path, e);
+                    logger.error("Error when deleting file", path, e);
                 }
 
                 // Propagate the error.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -26,11 +26,6 @@
 (function () {
     "use strict";
 
-    var logging = require("./logging"),
-        _loggerManager = new logging.LoggerManager(logging.LOG_LEVEL_INFO),
-        _logger = _loggerManager.createLogger("core"),
-        logStream = new logging.StreamFormatter(_loggerManager);
-
     var EventEmitter = require("events").EventEmitter,
         Q = require("q"),
         photoshop = require("./photoshop"),
@@ -81,10 +76,14 @@
     /**
      * @constructor
      */
-    function Generator() {
+    function Generator(loggerManager) {
         if (!(this instanceof Generator)) {
-            return new Generator();
+            return new Generator(loggerManager);
         }
+
+        this._loggerManager = loggerManager;
+        this._logger = loggerManager.createLogger("core");
+
         // TODO: declare these as prototype properties and document types
         this._plugins = {};
         this._photoshop = null;
@@ -99,8 +98,8 @@
     util.inherits(Generator, EventEmitter);
 
 
-    function createGenerator() {
-        return new Generator();
+    function createGenerator(loggerManager) {
+        return new Generator(loggerManager);
     }
 
     Object.defineProperty(Generator.prototype, "version", {enumerable: true, value: packageConfig.version});
@@ -112,26 +111,26 @@
         self._options = options;
         self._config = options.config || {};
 
-        _logger.info("Launching with config:\n%s", JSON.stringify(self._config, null, "  "));
+        this._logger.info("Launching with config:\n%s", JSON.stringify(self._config, null, "  "));
         if (options.photoshopVersion) {
-            _logger.info("provided PS information:\n version %s\n path%s\n",
+            this._logger.info("provided PS information:\n version %s\n path%s\n",
                 options.photoshopVersion, options.photoshopPath);
         }
 
         function connectToPhotoshop() {
             var connectionDeferred = Q.defer();
-            self._photoshop = photoshop.createClient(options, undefined, _logger);
+            self._photoshop = photoshop.createClient(options, undefined, self._logger);
             self._photoshop.once("connect", function () {
                 connectionDeferred.resolve(self);
             });
 
             self._photoshop.on("close", function () {
-                _logger.info("Photoshop connection closed");
+                self._logger.info("Photoshop connection closed");
                 self.emit("close");
             });
 
             self._photoshop.on("error", function (err) {
-                _logger.warn("Photoshop error", err);
+                self._logger.warn("Photoshop error", err);
                 // If the error does refers to a specific command we ran, reject the corresponding deferred
                 if (err && self._messageDeferreds.hasOwnProperty(err.id)) {
                     self._messageDeferreds[err.id].reject(err.body);
@@ -140,7 +139,7 @@
             });
 
             self._photoshop.on("communicationsError", function (err, rawMessage) {
-                _logger.warn("photoshop communications error: %j", {error: err, rawMessage: rawMessage});
+                self._logger.warn("photoshop communications error: %j", {error: err, rawMessage: rawMessage});
             });
 
             self._photoshop.on("message", function (messageID, parsedValue) { // ,rawMessage)
@@ -150,7 +149,7 @@
             });
 
             self._photoshop.on("info", function (info) {
-                _logger.info("Photoshop info: %j", info);
+                self._logger.info("Photoshop info: %j", info);
             });
 
             self._photoshop.on("event", function (messageID, eventName, parsedValue) { // , rawMessage)
@@ -207,8 +206,7 @@
                             self._paths.pngquant = pngquantPath;
                         })
                         .fail(function (err) {
-                            _logger.warning("PNGQuant binary is missing. PNGQuant functionality will not be available.",
-                                err);
+                            self._logger.warn("PNGQuant binary is missing. functionality will not be available.", err);
                             self._paths.pngquant = null;
                         });
 
@@ -221,7 +219,7 @@
                             self._paths.flite = flitePath;
                         })
                         .fail(function (err) {
-                            _logger.warning("flitetranscoder binary is missing." +
+                            self._logger.warning("flitetranscoder binary is missing." +
                                             " flite functionality will not be available.",
                                 err);
                             self._paths.flite = null;
@@ -236,7 +234,7 @@
             return self.getPhotoshopVersion().then(function (version) {
                 var requiredVersion = packageConfig["photoshop-version"];
 
-                _logger.info("Detected Photoshop version: %s", version);
+                self._logger.info("Detected Photoshop version: %s", version);
                 if (!semver.satisfies(version, requiredVersion)) {
                     var template = "Generator version %s requires Photoshop version %s",
                         message = util.format(template, packageConfig.version, requiredVersion);
@@ -366,7 +364,7 @@
         };
 
         Q.spread([loadJSX(path), stringifyParams(params)], function (jsx, paramsString) {
-            _logger.debug("Sending JSX file with params", path, paramsString);
+            self._logger.debug("Sending JSX file with params", path, paramsString);
             var data = "var params = " + paramsString + ";\n" + jsx;
             self._sendJSXString(data, deferred, sharedEngineSafe);
         })
@@ -851,7 +849,7 @@
                 return JSON.parse(settings.json);
             }
             catch (e) {
-                _logger.error("Could not parse" + settings.json + ": " + e.stack);
+                this._logger.error("Could not parse" + settings.json + ": " + e.stack);
             }
         }
         return settings;
@@ -903,11 +901,11 @@
             registerFunction = isOnce ? self.once : self.on;
 
         if (event === "imageChanged") {
-            _logger.warn("WARNING the imageChanged event is expensive, please consider NOT listening to it");
+            self._logger.warn("WARNING the imageChanged event is expensive, please consider NOT listening to it");
         }
 
         self.subscribeToPhotoshopEvents(event).fail(function () {
-            _logger.error("Failed to subscribe to photoshop event %s", event);
+            self._logger.error("Failed to subscribe to photoshop event %s", event);
             self.removePhotoshopEventListener(event, listener);
         });
 
@@ -1058,7 +1056,7 @@
      */
     Generator.prototype.getPixmap = function (documentId, layerSpec, settings) {
         if (arguments.length !== 3) {
-            _logger.warn("Call to getPixmap with " + arguments.length +
+            this._logger.warn("Call to getPixmap with " + arguments.length +
                 " instead of 3 arguments - outdated plugin?");
         }
         var self              = this,
@@ -1124,7 +1122,7 @@
             } else if (message.type === "iccProfile") {
                 profileDeferred.resolve(message.value);
             } else {
-                _logger.warn("Unexpected response from Photoshop:", message);
+                self._logger.warn("Unexpected response from Photoshop:", message);
                 executionDeferred.reject("Unexpected response from Photoshop");
             }
         });
@@ -1258,7 +1256,7 @@
         executionDeferred.promise.progress(function (message) {
             if (timeoutTimer === null) { // First message we've received
                 timeoutTimer = setTimeout(function () {
-                    _logger.warn("getLayerShape request timed out");
+                    self._logger.warn("getLayerShape request timed out");
                     executionDeferred.resolve(); // done listening for messages
                     resultDeferred.reject("timeout");
                 }, MULTI_MESSAGE_TIMEOUT);
@@ -1697,7 +1695,7 @@
         this._parsePixmapProperties(pixmap);
         this._parsePixmapSaveSettings(settings);
 
-        return convert.savePixmap(this._paths, pixmap, path, settings, _logger);
+        return convert.savePixmap(this._paths, pixmap, path, settings, this._logger);
     };
 
     /**
@@ -1709,7 +1707,7 @@
     Generator.prototype.streamPixmap = function (pixmap, outputStream, settings) {
         this._parsePixmapProperties(pixmap);
         this._parsePixmapSaveSettings(settings);
-        return convert.streamPixmap(this._paths, pixmap, outputStream, settings, _logger);
+        return convert.streamPixmap(this._paths, pixmap, outputStream, settings, this._logger);
     };
 
     /**
@@ -1900,10 +1898,10 @@
         compatibility = self.checkPluginCompatibility(metadata);
         if (!compatibility.compatible) {
             handleIncompatiblePlugin(metadata);
-            _logger.error(compatibility.message);
+            self._logger.error(compatibility.message);
             throw new Error(compatibility.message);
         } else if (compatibility.message) {
-            _logger.warn(compatibility.message);
+            self._logger.warn(compatibility.message);
         }
 
         // Check for uniqueness
@@ -1914,14 +1912,14 @@
 
         // Do the actual plugin load
         try {
-            _logger.info("Loading plugin: %s (v%s) from directory: %s", metadata.name, metadata.version, directory);
+            self._logger.info("Loading plugin: %s (v%s) from: %s", metadata.name, metadata.version, directory);
             // NOTE: We don't need to worry about accidentally requiring the same plugin twice.
             // If the user did try to load it twice, require's caching would return the same
             // package.json both times (even if the package.json changed on disk), and so
             // we'd get the same name both times, and bail in the "if" branch above.
             var plugin = require(directory),
                 config = self._config[metadata.name] || {},
-                logger = _loggerManager.createLogger(metadata.name);
+                logger = self._loggerManager.createLogger(metadata.name);
 
             plugin.init(this, config, logger);
             self._plugins[PLUGIN_KEY_PREFIX + metadata.name] = {
@@ -1930,7 +1928,7 @@
                 config: config,
                 logger: logger
             };
-            _logger.info("Plugin loaded: %s", metadata.name);
+            self._logger.info("Plugin loaded: %s", metadata.name);
             self._logHeadlightsPluginLoaded(metadata.name, metadata.version);
         } catch (loadError) {
             throw new Error("Could not load plugin at path '" + directory + "': " + loadError.message);
@@ -1983,10 +1981,10 @@
                 } else if (settings === "") {
                     return {};
                 } else {
-                    _logger.warn("Unexpected custom options:", settings);
+                    this._logger.warn("Unexpected custom options:", settings);
                     return {};
                 }
-            })
+            }.bind(this))
             .catch(function () {
                 return {};
             });
@@ -2136,7 +2134,7 @@
 
     exports.Generator         = Generator;
     exports.createGenerator   = createGenerator;
-    exports.logStream         = logStream;
+    exports.logStream         = null; // this is now set by app.js, leaving here for backward compat
     exports._escapePluginId   = escapePluginId;
     exports._unescapePluginId = unescapePluginId;
 

--- a/lib/photoshop.js
+++ b/lib/photoshop.js
@@ -464,7 +464,7 @@
         // Evaluate communication status
         var commStatus = this._receiveBuffer.readInt32BE(MESSAGE_STATUS_OFFSET);
         if (commStatus !== STATUS_NO_COMM_ERROR) {
-            console.error("Communication error: " + commStatus);
+            this._logger.error("Communication error: " + commStatus);
             this.emit("communicationsError", "Photoshop communication error: " + commStatus);
             this.disconnect();
             return;

--- a/lib/rpc/DomainManager.js
+++ b/lib/rpc/DomainManager.js
@@ -113,7 +113,7 @@
             
             this._domains[domainName] = {version: version, commands: {}, events: {}};
         } else {
-            console.error("Domain " + domainName + " already registered");
+            this._logger.error("Domain " + domainName + " already registered");
         }
     };
     
@@ -231,7 +231,7 @@
                 parameters: parameters
             };
         } else {
-            console.error("Event " + domainName + "." + eventName + " already registered");
+            this._logger.error("Event " + domainName + "." + eventName + " already registered");
         }
     };
 
@@ -256,7 +256,7 @@
                 parameters
             );
         } else {
-            console.error("No such event: " + domainName + "." + eventName);
+            this._logger.error("No such event: " + domainName + "." + eventName);
         }
     };
     


### PR DESCRIPTION
Anything logged via `console.log` (and debug, error, warn) will make its way to the Photoshop stdout which we don't want.  The biggest change in this PR is to create the `loggerManager` in app.js and pass it to generator (where it previously lived).  Smaller changes include using logger (instead of console) where it is was already more readily available.