### PR TITLE
Better logging of JSX errors, suppress getDocumentInfo error when no documents are open

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -372,8 +372,13 @@
             deferred.reject(err);
         });
 
-        return deferred;
+        // Log a warning when any JSX file throws an exception
+        // This is helpful for troubleshooting because it ties an error back to a specific JSX file
+        deferred.promise.fail(function (err) {
+            self._logger.warn("Error in JSX file with params", path, params, err);
+        });
 
+        return deferred;
     };
 
     /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -680,7 +680,13 @@
             });
         }
 
-        return this.evaluateJSXFileSharedSafe("./jsx/getDocumentInfo.jsx", params);
+        return this.evaluateJSXFileSharedSafe("./jsx/getDocumentInfo.jsx", params).then(function (docInfo) {
+            // This JSX will return null if there are no documents open
+            if (!docInfo) {
+                return Q.reject("No Open Document");
+            }
+            return docInfo;
+        });
     };
 
     /**

--- a/lib/jsx/getDocumentInfo.jsx
+++ b/lib/jsx/getDocumentInfo.jsx
@@ -1,4 +1,4 @@
-/*global stringIDToTypeID, ActionDescriptor, executeAction, DialogModes, params */
+/*global stringIDToTypeID, ActionDescriptor, executeAction, DialogModes, params, app */
 // Required params:
 //   - flags: An object with flags as keys and boolean values
 //     Sample: {
@@ -32,4 +32,9 @@ for (k in flags) {
 if (params.documentId) {
     desc.putInteger(stringIDToTypeID("documentID"), params.documentId);
 }
-executeAction(idNS, desc, DialogModes.NO);
+
+if (app.documents.length) {
+    executeAction(idNS, desc, DialogModes.NO);
+} else {
+    null; // jshint ignore:line
+}


### PR DESCRIPTION
1. It is sometimes hard to tell via the generator logs which JSX script failed.  The first commit adds an explicit log warning
2. If generator-assets polls for document info when no documents are open, the JSX script throws.  This is already handled gracefully, but it adds meaningless clutter in the logs.  This is even worse now with the logging added in this PR, so the second commit changes the JSX to return "null" in this particular case.