### PR TITLE
Use new command line argument to set the log root

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,7 @@
         "photoshopVersion": null,
         "photoshopPath": null,
         "photoshopBinaryPath": null,
+        "photoshopLogPath": null,
         "whiteListedPlugins": null
     });
 
@@ -79,6 +80,7 @@
             "photoshopVersion": "tell Generator PS's version so it isn't queried at startup (optional)",
             "photoshopPath": "tell Generator PS's path so it isn't queried at startup (optional)",
             "photoshopBinaryPath": "tell Generator PS's binary location so it isn't queried at startup (optional)",
+            "photoshopLogPath": "log root directory, required for generator built in mode",
             "whiteListedPlugins": "A comma seperated list of plugin names that are ok to run (optional)",
             "help": "display help message"
         }).alias({
@@ -97,9 +99,17 @@
         process.exit(0);
     }
 
+    // Warn when photoshopLogPath not supplied.
+    // This is probably OK, and only applicable to "remote" generator development
+    if (!argv.photoshopLogPath) {
+        console.log(
+            "Generator did not receive a log location via 'photoshopLogPath' param; may use a non-standard location");
+    }
+
     var logSettings = {
         vendor:      "Adobe",
-        application: "Adobe Photoshop CC 2019",
+        application: "Adobe Photoshop Generator", // for fall-back log location when photoshopLogPath not given
+        logRoot:     argv.photoshopLogPath,
         module:      "Generator",
         verbose:     argv.verbose
     };

--- a/lib/stdlog.js
+++ b/lib/stdlog.js
@@ -148,7 +148,9 @@
         var elements,
             platform = process.platform;
 
-        if (platform === "darwin") {
+        if (settings.logRoot) {
+            elements = [settings.logRoot, settings.module];
+        } else if (platform === "darwin") {
             elements = [process.env.HOME, "Library", "Logs", settings.vendor, settings.application, settings.module];
         } else if (platform === "win32") {
             elements = [process.env.APPDATA, settings.vendor, settings.application, settings.module, "logs"];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-core",
   "version": "3.11.6",
-  "photoshop-version": ">=19.0",
+  "photoshop-version": ">=20.0",
   "description": "Adobe Photoshop Generator Core",
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
Beginning in PS v20, a new param is provided to generator: `photoshopLogPath`.  This allows the log root to be provided by PS instead of derived based on hardcoded values (the location is PS version specific).  If not provided (such as when running "remote" during development) it will fall back on a generic `Adobe Photoshop Generator` location.

This PR sets the minimum version of PS to version 20