### PR TITLE
Add a warn about symlink plugins not being supported anymore

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1942,6 +1942,12 @@
             self._logger.info("Plugin loaded: %s", metadata.name);
             self._logHeadlightsPluginLoaded(metadata.name, metadata.version);
         } catch (loadError) {
+            if (loadError.code === "MODULE_NOT_FOUND") {
+                self._logger.warn(
+                  "Failed to load a module for the plugin %s. " +
+                  "If you were using symlink to keep plugins in development linked to the plugins folder " +
+                  "then that is not supported anymore.", metadata.name);
+            }
             throw new Error("Could not load plugin at path '" + directory + "': " + loadError.message);
         }
     };


### PR DESCRIPTION
Hey there 👋 

A recent change broke the plugins local development setup for me https://github.com/adobe-photoshop/generator-core/pull/419. I used to use symlink to keep the plugin I am working on in development in a different folder:
```
/Users/myuser/Development/mycompany/generator
├── generator-core
└── plugins
    └── myplugin -> /Users/myuser/Development/mycompany/myplugin
```
With that recent change, any dependency of my plugin returns this error message:
```
Unable to load plugin at '/Users/myuser/Development/mycompany/generator/plugins/myplugin': Could not load plugin at path '/Users/myuser/Development/mycompany/generator/plugins/myplugin': Cannot find module 'some-dependency-of-myplugin'
```
That happens because that recent change hacks the modules loading system and only allows modules to be loaded from the generator directory. But because I am using symlink it gets the resolved path to the original source which is in a different directory and it blocks any module from being loaded.

It took me a few hours to understand this was the problem. So, it would be nice to at least show a warn message in case other people go through the same issue. Or if we could have that recent change disabled in development it would allow us using symlink back in development.