### PR TITLE
Remove usePSClipping from params

### DIFF
--- a/lib/jsx/getLayerPixmap.jsx
+++ b/lib/jsx/getLayerPixmap.jsx
@@ -228,7 +228,7 @@ if (params.hasOwnProperty("clipToDocumentBounds")) {
     actionDescriptor.putBoolean(stringIDToTypeID("clipToDocumentBounds"), !!params.clipToDocumentBounds);
 }
 
-if (params.clipBounds && params.usePSClipping) {
+if (params.clipBounds) {
 
     // The part of the document to use
     var clipBounds = params.clipBounds,


### PR DESCRIPTION
"params.usePSClipping" is used only here and block "clipBounds" parameter