### PR TITLE
Write process.version to log.

### DIFF
--- a/lib/stdlog.js
+++ b/lib/stdlog.js
@@ -221,6 +221,7 @@
         }
 
         writeToLog("Log file created on " + new Date() + "\n\n");
+        writeToLog("Node.js version: " + process.version + "\n\n");
     }
 
     exports.setup = setup;


### PR DESCRIPTION
The second item written to the generator log file shall be the Node.js version that is currently in use.

This information is very helpful when debugging as well as testing an update to the node executable that is bundled with Ps.